### PR TITLE
feat/회원가입-이메일 OTP 인증 구현

### DIFF
--- a/lib/auth/data/data_source/auth_data_source.dart
+++ b/lib/auth/data/data_source/auth_data_source.dart
@@ -6,5 +6,8 @@ abstract interface class AuthDataSource {
   Future<void> logout();
   Future<bool> isEmailExist(String email);
   Future<void> saveUser();
+  Future<void> sendOtp(String email);
+  Future<AuthResponse> verifyOtp(String email, String otp);
+  Future<UserResponse> resetPassword(String email);
   bool isAuthenticated();
 }

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -50,6 +50,31 @@ class AuthDataSourceImpl implements AuthDataSource {
   }
 
   @override
+  Future<UserResponse> resetPassword(String password) async {
+    final response = await _client.auth.updateUser(
+      UserAttributes(password: password),
+    );
+
+    return response;
+  }
+
+  @override
+  Future<void> sendOtp(String email) async {
+    await _client.auth.signInWithOtp(email: email);
+  }
+
+  @override
+  Future<AuthResponse> verifyOtp(String email, String otp) async {
+    final response = await _client.auth.verifyOTP(
+      email: email,
+      token: otp,
+      type: OtpType.email,
+    );
+
+    return response;
+  }
+
+  @override
   bool isAuthenticated() {
     final user = _client.auth.currentUser;
     if (user == null) {

--- a/lib/auth/data/repository/auth_repository_impl.dart
+++ b/lib/auth/data/repository/auth_repository_impl.dart
@@ -176,7 +176,7 @@ class AuthRepositoryImpl extends AuthRepository {
     } catch (e) {
       return Result.error(
         AppException.unknown(
-          message: '인증 번호 전송을 실패하였습니다.',
+          message: '인증번호 전송을 실패하였습니다.',
           error: e,
           stackTrace: StackTrace.current,
         ),
@@ -187,23 +187,13 @@ class AuthRepositoryImpl extends AuthRepository {
   @override
   Future<Result<void, AppException>> verifyOtp(String email, String otp) async {
     try {
-      final authResponse = await _authDataSource.verifyOtp(email, otp);
-
-      if (authResponse.session == null) {
-        return Result.error(
-          AppException.invalidOtp(
-            message: '인증 번호가 유효하지 않습니다.',
-            error: null,
-            stackTrace: StackTrace.current,
-          ),
-        );
-      }
+      await _authDataSource.verifyOtp(email, otp);
 
       return const Result.success(null);
     } catch (e) {
       return Result.error(
         AppException.unknown(
-          message: '알 수 없는 오류입니다.',
+          message: '인증번호가 일치하지 않습니다.',
           error: e,
           stackTrace: StackTrace.current,
         ),

--- a/lib/auth/data/repository/auth_repository_impl.dart
+++ b/lib/auth/data/repository/auth_repository_impl.dart
@@ -134,6 +134,84 @@ class AuthRepositoryImpl extends AuthRepository {
   }
 
   @override
+  Future<Result<void, AppException>> resetPassword(String password) async {
+    try {
+      if (!isAuthenticated) {
+        return Result.error(
+          AppException.unAuthorized(
+            message: '인증되지 않은 사용자입니다.',
+            error: null,
+            stackTrace: StackTrace.current,
+          ),
+        );
+      }
+
+      final userResponse = await _authDataSource.resetPassword(password);
+      if (userResponse.user == null) {
+        return Result.error(
+          AppException.unknown(
+            message: '비밀번호 설정에 실패하였습니다.',
+            error: null,
+            stackTrace: StackTrace.current,
+          ),
+        );
+      }
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(
+        AppException.unknown(
+          message: '알 수 없는 오류입니다.',
+          error: e,
+          stackTrace: StackTrace.current,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<Result<void, AppException>> sendOtp(String email) async {
+    try {
+      await _authDataSource.sendOtp(email);
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(
+        AppException.unknown(
+          message: '인증 번호 전송을 실패하였습니다.',
+          error: e,
+          stackTrace: StackTrace.current,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<Result<void, AppException>> verifyOtp(String email, String otp) async {
+    try {
+      final authResponse = await _authDataSource.verifyOtp(email, otp);
+
+      if (authResponse.session == null) {
+        return Result.error(
+          AppException.invalidOtp(
+            message: '인증 번호가 유효하지 않습니다.',
+            error: null,
+            stackTrace: StackTrace.current,
+          ),
+        );
+      }
+
+      return const Result.success(null);
+    } catch (e) {
+      return Result.error(
+        AppException.unknown(
+          message: '알 수 없는 오류입니다.',
+          error: e,
+          stackTrace: StackTrace.current,
+        ),
+      );
+    }
+  }
+
+  @override
   bool get isAuthenticated {
     return _authDataSource.isAuthenticated();
   }

--- a/lib/auth/domain/repository/auth_repository.dart
+++ b/lib/auth/domain/repository/auth_repository.dart
@@ -10,4 +10,7 @@ abstract class AuthRepository extends ChangeNotifier {
   Future<Result<void, AppException>> signOut();
   Future<Result<bool, AppException>> isEmailExist(String email);
   Future<Result<void, AppException>> saveUser();
+  Future<Result<void, AppException>> sendOtp(String email);
+  Future<Result<void, AppException>> verifyOtp(String email, String otp);
+  Future<Result<void, AppException>> resetPassword(String password);
 }

--- a/lib/auth/presentation/sign_up/controller/sign_up_action.dart
+++ b/lib/auth/presentation/sign_up/controller/sign_up_action.dart
@@ -8,4 +8,5 @@ sealed class SignUpAction with _$SignUpAction {
   const factory SignUpAction.onTapTermsOfUse() = OnTapTermsOfUse;
   const factory SignUpAction.onTapSignUp() = OnTapSignUp;
   const factory SignUpAction.onTapSignIn() = OnTapSignIn;
+  const factory SignUpAction.onTapOtpSend() = OnTapOtpSend;
 }

--- a/lib/auth/presentation/sign_up/controller/sign_up_state.dart
+++ b/lib/auth/presentation/sign_up/controller/sign_up_state.dart
@@ -9,6 +9,7 @@ abstract class SignUpState with _$SignUpState {
     @Default(false) bool isEmailCompleted,
     @Default(false) bool isTermsOfUseChecked,
     required TextEditingController emailController,
+    required TextEditingController codeController,
     required TextEditingController passwordController,
     required TextEditingController passwordConfirmController,
   }) = _SignUpState;

--- a/lib/auth/presentation/sign_up/controller/sign_up_view_model.dart
+++ b/lib/auth/presentation/sign_up/controller/sign_up_view_model.dart
@@ -20,6 +20,7 @@ class SignUpViewModel extends _$SignUpViewModel {
   SignUpState build() {
     return SignUpState(
       emailController: TextEditingController(),
+      codeController: TextEditingController(),
       passwordController: TextEditingController(),
       passwordConfirmController: TextEditingController(),
     );

--- a/lib/auth/presentation/sign_up/controller/sign_up_view_model.dart
+++ b/lib/auth/presentation/sign_up/controller/sign_up_view_model.dart
@@ -76,4 +76,49 @@ class SignUpViewModel extends _$SignUpViewModel {
         return false;
     }
   }
+
+  Future<void> sendOtp() async {
+    final authRepository = ref.read(authRepositoryProvider);
+    final result = await authRepository.sendOtp(state.emailController.text);
+
+    switch (result) {
+      case Success<void, AppException>():
+        _eventController.add(const SignUpEvent.showSnackBar('인증번호가 발송되었습니다.'));
+        return;
+      case Error<void, AppException>():
+        _eventController.add(SignUpEvent.showSnackBar(result.error.message));
+        return;
+    }
+  }
+
+  Future<bool> verifyOtp() async {
+    final authRepository = ref.read(authRepositoryProvider);
+    final result = await authRepository.verifyOtp(
+      state.emailController.text,
+      state.codeController.text,
+    );
+
+    switch (result) {
+      case Success<void, AppException>():
+        return true;
+      case Error<void, AppException>():
+        _eventController.add(SignUpEvent.showSnackBar(result.error.message));
+        return false;
+    }
+  }
+
+  Future<bool> resetPassword() async {
+    final authRepository = ref.read(authRepositoryProvider);
+    final result = await authRepository.resetPassword(
+      state.passwordController.text,
+    );
+
+    switch (result) {
+      case Success<void, AppException>():
+        return true;
+      case Error<void, AppException>():
+        _eventController.add(SignUpEvent.showSnackBar(result.error.message));
+        return false;
+    }
+  }
 }

--- a/lib/auth/presentation/sign_up/screen/sign_up_screen.dart
+++ b/lib/auth/presentation/sign_up/screen/sign_up_screen.dart
@@ -16,22 +16,26 @@ class SignUpScreen extends StatefulWidget {
 class _SignUpScreenState extends State<SignUpScreen> {
   final formKey = GlobalKey<FormState>();
 
-  bool get _isFormValid => widget.state.emailController.text.isNotEmpty;
+  bool get _isFormValid =>
+      widget.state.emailController.text.isNotEmpty &&
+      widget.state.codeController.text.isNotEmpty;
 
   @override
   void initState() {
     super.initState();
-    widget.state.emailController.addListener(() {
-      setState(() {}); // 이메일 입력값이 변경될 때마다 화면 갱신
-    });
+    widget.state.emailController.addListener(_onInputChanged);
+    widget.state.codeController.addListener(_onInputChanged);
   }
 
   @override
   void dispose() {
-    widget.state.emailController.removeListener(() {
-      setState(() {});
-    });
+    widget.state.emailController.removeListener(_onInputChanged);
+    widget.state.codeController.removeListener(_onInputChanged);
     super.dispose();
+  }
+
+  void _onInputChanged() {
+    setState(() {});
   }
 
   @override
@@ -40,6 +44,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
       backgroundColor: Colors.white,
       body: Center(
         child: Container(
+          width: MediaQuery.sizeOf(context).width * 0.25,
           padding: const EdgeInsets.all(32.0),
           color: Colors.white,
           child: Form(
@@ -64,13 +69,22 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   style: TextStyle(fontSize: 28, fontWeight: FontWeight.w500),
                 ),
                 const Gap(35),
-                SizedBox(
-                  width: MediaQuery.of(context).size.width * 0.25,
-                  child: BaseTextField(
-                    hintText: '이메일 주소를 입력해주세요',
-                    controller: widget.state.emailController,
-                    validator: _validator,
+                BaseTextField(
+                  hintText: '이메일 주소를 입력해주세요',
+                  controller: widget.state.emailController,
+                  validator: _emailValidator,
+                  suffix: GestureDetector(
+                    onTap:
+                        () =>
+                            widget.onAction(const SignUpAction.onTapOtpSend()),
+                    child: const Icon(Icons.send, color: Colors.grey),
                   ),
+                ),
+                const Gap(20),
+                BaseTextField(
+                  hintText: '인증번호를 입력해주세요',
+                  controller: widget.state.codeController,
+                  validator: _codeValidator,
                 ),
                 const Gap(20),
                 GestureDetector(
@@ -80,7 +94,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
                     }
                   },
                   child: Container(
-                    width: MediaQuery.of(context).size.width * 0.25,
+                    width: double.infinity,
                     padding: const EdgeInsets.symmetric(vertical: 12.5),
                     decoration: BoxDecoration(
                       color:
@@ -117,7 +131,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
     );
   }
 
-  String? _validator(value) {
+  String? _emailValidator(value) {
     if (value == null || value.isEmpty) {
       return '이메일을 입력해주세요.';
     }
@@ -126,6 +140,16 @@ class _SignUpScreenState extends State<SignUpScreen> {
     );
     if (!emailRegex.hasMatch(value)) {
       return '유효한 이메일 주소를 입력해주세요.';
+    }
+    return null;
+  }
+
+  String? _codeValidator(String? value) {
+    if (value == null || value.isEmpty) {
+      return '인증번호를 입력해주세요.';
+    }
+    if (value.length != 6 || !RegExp(r'^[0-9]+$').hasMatch(value)) {
+      return '6자리 숫자를 입력해주세요.';
     }
     return null;
   }

--- a/lib/auth/presentation/sign_up/screen/sign_up_screen.dart
+++ b/lib/auth/presentation/sign_up/screen/sign_up_screen.dart
@@ -74,9 +74,10 @@ class _SignUpScreenState extends State<SignUpScreen> {
                   controller: widget.state.emailController,
                   validator: _emailValidator,
                   suffix: GestureDetector(
-                    onTap:
-                        () =>
-                            widget.onAction(const SignUpAction.onTapOtpSend()),
+                    onTap: () {
+                      FocusScope.of(context).unfocus();
+                      widget.onAction(const SignUpAction.onTapOtpSend());
+                    },
                     child: const Icon(Icons.send, color: Colors.grey),
                   ),
                 ),

--- a/lib/auth/presentation/sign_up/screen/sign_up_screen_root.dart
+++ b/lib/auth/presentation/sign_up/screen/sign_up_screen_root.dart
@@ -60,14 +60,14 @@ class _SignUpScreenRootState extends ConsumerState<SignUpScreenRoot> {
 
     switch (action) {
       case OnTapStart():
-        if (await viewModel.checkEmail()) {
+        if (await viewModel.verifyOtp()) {
           viewModel.isEmailCompleted = true;
         }
       case OnTapTermsOfUse():
         viewModel.toggleTermsOfUse();
       case OnTapSignUp():
-        final isUserRegistered = await viewModel.signUp();
-        if (isUserRegistered) {
+        final isPasswordUpdated = await viewModel.resetPassword();
+        if (isPasswordUpdated) {
           if (await viewModel.saveUser() && mounted) {
             context.go(Routes.signUpComplete);
           }
@@ -75,7 +75,9 @@ class _SignUpScreenRootState extends ConsumerState<SignUpScreenRoot> {
       case OnTapSignIn():
         context.go(Routes.signIn);
       case OnTapOtpSend():
-      // TODO: OTP 전송 로직 구현
+        if (await viewModel.checkEmail()) {
+          viewModel.sendOtp();
+        }
     }
   }
 }

--- a/lib/auth/presentation/sign_up/screen/sign_up_screen_root.dart
+++ b/lib/auth/presentation/sign_up/screen/sign_up_screen_root.dart
@@ -74,6 +74,8 @@ class _SignUpScreenRootState extends ConsumerState<SignUpScreenRoot> {
         }
       case OnTapSignIn():
         context.go(Routes.signIn);
+      case OnTapOtpSend():
+      // TODO: OTP 전송 로직 구현
     }
   }
 }

--- a/lib/core/component/base_text_field.dart
+++ b/lib/core/component/base_text_field.dart
@@ -6,6 +6,7 @@ class BaseTextField extends StatelessWidget {
   final TextEditingController? controller;
   final void Function(String)? onChanged;
   final bool isObscure;
+  final Widget? suffix;
 
   const BaseTextField({
     super.key,
@@ -14,6 +15,7 @@ class BaseTextField extends StatelessWidget {
     this.controller,
     this.isObscure = false,
     this.onChanged,
+    this.suffix,
   });
 
   @override
@@ -22,6 +24,7 @@ class BaseTextField extends StatelessWidget {
       onChanged: onChanged,
       controller: controller,
       decoration: InputDecoration(
+        suffixIcon: suffix,
         hintText: hintText,
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(8),

--- a/lib/core/exception/app_exception.dart
+++ b/lib/core/exception/app_exception.dart
@@ -65,11 +65,18 @@ sealed class AppException with _$AppException implements Exception {
     Object? error,
     StackTrace? stackTrace,
   }) = PdfDownloadException;
+
   const factory AppException.unAuthorized({
     required String message,
     Object? error,
     StackTrace? stackTrace,
   }) = UnAuthorizedException;
+
+  const factory AppException.invalidOtp({
+    required String message,
+    Object? error,
+    StackTrace? stackTrace,
+  }) = InvalidOtpException;
 
   String get userFriendlyMessage {
     switch (this) {
@@ -94,6 +101,8 @@ sealed class AppException with _$AppException implements Exception {
         return '다운로드 중 에러가 발생하였습니다.';
       case UnAuthorizedException():
         return '인증되지 않은 사용자입니다.';
+      case InvalidOtpException():
+        return '유효하지 않은 인증번호입니다.';
     }
   }
 }


### PR DESCRIPTION
## 🔍 변경사항 요약
- 회원가입 시 이메일 OTP로 인증 처리

## 📌 리뷰사항
- 이메일 입력 후 suffixIcon 클릭 -> 인증번호 발송 SnackBar 표시
- '인증번호 발송 실패하였습니다'일 경우 아이콘 다시 클릭
- 인증번호 입력 후 '이메일로 시작하기' 클릭
- 인증번호 미일치 시 '인증번호가 일치하지 않습니다.' SnackBar 표시
- 비밀번호 설정 페이지에서 비밀번호 설정 후 회원가입하기 클릭
- 비밀번호 설정 성공 시 가입 완료 페이지 이동

위 흐름에 문제가 없어야 합니다

![image](https://github.com/user-attachments/assets/f1f03e0a-f43c-42aa-a4a2-57a8dcdf39aa)

## ✅ 체크리스트
- [x] 코드가 빌드 및 실행에 문제 없는가
- [x] 파일, 변수, 주석 등이 컨벤션 규칙에 맞게 준수되었는가
- [x] 변경된 코드가 기존 기능에 영향을 주지 않도록 설계되었는가
- [x] 변경된 파일에 대한 문서나 주석이 업데이트 되었는가
- [x] 리뷰어가 이해하기 쉽도록 변경사항 설명 작성

## 📝 추가 참고사항 (선택)
- 테스트 방법, 고려사항, 관련 자료 등이 있다면 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이메일로 OTP(인증번호) 전송, OTP 인증, 비밀번호 재설정 기능이 추가되었습니다.
  - 회원가입 화면에 OTP 입력란과 OTP 전송 버튼이 추가되었습니다.
  - 입력 필드에 커스텀 아이콘(예: OTP 전송 버튼) 표시가 가능해졌습니다.

- **버그 수정**
  - 폼 유효성 검사 로직이 개선되어 이메일과 OTP 입력이 모두 필요하도록 변경되었습니다.

- **사용성 개선**
  - OTP 인증 실패 시 사용자에게 "유효하지 않은 인증번호입니다."라는 안내 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->