### PR TITLE
Feat/Workbook CRUD, 우클릭 상호작용 추가

### DIFF
--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -44,6 +44,9 @@ import 'package:mongo_ai/dashboard/domain/repository/folder_repository.dart';
 import 'package:mongo_ai/dashboard/domain/repository/team_repository.dart';
 import 'package:mongo_ai/dashboard/domain/repository/user_profile_repository.dart';
 import 'package:mongo_ai/dashboard/domain/repository/workbook_repository.dart';
+import 'package:mongo_ai/dashboard/domain/use_case/delete_workbook_use_case.dart';
+import 'package:mongo_ai/dashboard/domain/use_case/toggle_bookmark_use_case.dart';
+import 'package:mongo_ai/dashboard/domain/use_case/update_workbook_use_case.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final supabaseClientProvider = Provider<SupabaseClient>((ref) {
@@ -137,6 +140,21 @@ final getWorkbooksByCurrentTeamIdProvider =
       final repository = ref.watch(workbookRepositoryProvider);
       return repository.getWorkbooksByCurrentTeamId(teamId);
     });
+
+final toggleBookmarkUseCaseProvider = Provider<ToggleBookmarkUseCase>((ref) {
+  final workbookRepository = ref.watch(workbookRepositoryProvider);
+  return ToggleBookmarkUseCase(workbookRepository);
+});
+
+final deleteWorkbookUseCaseProvider = Provider<DeleteWorkbookUseCase>((ref) {
+  final workbookRepository = ref.watch(workbookRepositoryProvider);
+  return DeleteWorkbookUseCase(workbookRepository);
+});
+
+final updateWorkbookUseCaseProvider = Provider<UpdateWorkbookUseCase>((ref) {
+  final workbookRepository = ref.watch(workbookRepositoryProvider);
+  return UpdateWorkbookUseCase(workbookRepository);
+});
 
 // -----------------------------------
 // create

--- a/lib/dashboard/data/data_source/workbook_data_source.dart
+++ b/lib/dashboard/data/data_source/workbook_data_source.dart
@@ -1,5 +1,9 @@
-import 'package:mongo_ai/dashboard/data/dto/workbook_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_view_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_table_dto.dart';
 
 abstract interface class WorkbookDataSource {
-  Future<List<WorkbookDto>> getWorkbooksByCurrentTeamId(int teamId);
+  Future<List<WorkbookViewDto>> getWorkbooksByCurrentTeamId(int teamId);
+  Future<WorkbookViewDto> createWorkbook(WorkbookTableDto workbookTableDto);
+  Future<void> updateWorkbook(WorkbookTableDto workbookTableDto);
+  Future<void> deleteWorkbook(int workbookId);
 }

--- a/lib/dashboard/data/data_source/workbook_data_source_impl.dart
+++ b/lib/dashboard/data/data_source/workbook_data_source_impl.dart
@@ -1,5 +1,6 @@
 import 'package:mongo_ai/dashboard/data/data_source/workbook_data_source.dart';
-import 'package:mongo_ai/dashboard/data/dto/workbook_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_view_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_table_dto.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class WorkbookDataSourceImpl implements WorkbookDataSource {
@@ -10,14 +11,47 @@ class WorkbookDataSourceImpl implements WorkbookDataSource {
   }) : _client = client;
 
   @override
-  Future<List<WorkbookDto>> getWorkbooksByCurrentTeamId(int teamId) async {
+  Future<List<WorkbookViewDto>> getWorkbooksByCurrentTeamId(int teamId) async {
     final data = await _client
         .from('workbook_with_keyword_view')
         .select()
         .eq('team_id', teamId);
 
     return data
-        .map((e) => WorkbookDto.fromJson(e))
+        .map((e) => WorkbookViewDto.fromJson(e))
         .toList();
+  }
+
+  @override
+  Future<WorkbookViewDto> createWorkbook(WorkbookTableDto workbookTableDto) async {
+    // null인 필드는 Json에서 아예 삭제
+    final data = workbookTableDto.toJson()
+      ..removeWhere((key, value) => value == null);
+
+    // Workbook 생성 후 workbookId와 createdAt을 포함한 폴더 정보를 반환
+    final json = await _client
+        .from('workbook')
+        .insert(data)
+        .select()     // Select를 붙여야 반환이 가능
+        .single();
+
+    return WorkbookViewDto.fromJson(json);
+  }
+
+  @override
+  Future<void> updateWorkbook(WorkbookTableDto workbookTableDto) async {
+    // workbookId는 Workbook 모델에서 not null이므로 ! 사용
+    await _client
+        .from('workbook')
+        .update(workbookTableDto.toJson())
+        .eq('workbook_id', workbookTableDto.workbookId!.toInt());
+  }
+
+  @override
+  Future<void> deleteWorkbook(int workbookId) async {
+    await _client
+        .from('workbook')
+        .delete()
+        .eq('workbook_id', workbookId);
   }
 }

--- a/lib/dashboard/data/dto/workbook_table_dto.dart
+++ b/lib/dashboard/data/dto/workbook_table_dto.dart
@@ -1,9 +1,9 @@
 import 'package:json_annotation/json_annotation.dart';
 
-part 'workbook_dto.g.dart';
+part 'workbook_table_dto.g.dart';
 
 @JsonSerializable()
-class WorkbookDto {
+class WorkbookTableDto {
   @JsonKey(name: 'workbook_id')
   num? workbookId;
 
@@ -12,9 +12,6 @@ class WorkbookDto {
 
   @JsonKey(name: 'user_id')
   String? userId;
-
-  @JsonKey(name: 'user_name')
-  String? userName;
 
   @JsonKey(name: 'bookmark')
   bool? bookmark;
@@ -25,14 +22,8 @@ class WorkbookDto {
   @JsonKey(name: 'folder_id')
   num? folderId;
 
-  @JsonKey(name: 'folder_name')
-  String? folderName;
-
   @JsonKey(name: 'team_id')
   num? teamId;
-
-  @JsonKey(name: 'team_name')
-  String? teamName;
 
   @JsonKey(name: 'created_at')
   String? createdAt;
@@ -43,7 +34,7 @@ class WorkbookDto {
   @JsonKey(name: 'deleted_at')
   String? deletedAt;
 
-  WorkbookDto({
+  WorkbookTableDto({
     this.workbookId,
     this.userId,
     this.workbookName,
@@ -56,8 +47,8 @@ class WorkbookDto {
     this.deletedAt
   });
 
-  factory WorkbookDto.fromJson(Map<String, dynamic> json) =>
-      _$WorkbookDtoFromJson(json);
+  factory WorkbookTableDto.fromJson(Map<String, dynamic> json) =>
+      _$WorkbookTableDtoFromJson(json);
 
-  Map<String, dynamic> toJson() => _$WorkbookDtoToJson(this);
+  Map<String, dynamic> toJson() => _$WorkbookTableDtoToJson(this);
 }

--- a/lib/dashboard/data/dto/workbook_view_dto.dart
+++ b/lib/dashboard/data/dto/workbook_view_dto.dart
@@ -1,0 +1,65 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'workbook_view_dto.g.dart';
+
+@JsonSerializable()
+class WorkbookViewDto {
+  @JsonKey(name: 'workbook_id')
+  num? workbookId;
+
+  @JsonKey(name: 'workbook_name')
+  String? workbookName;
+
+  @JsonKey(name: 'user_id')
+  String? userId;
+
+  @JsonKey(name: 'user_name')
+  String? userName;
+
+  @JsonKey(name: 'bookmark')
+  bool? bookmark;
+
+  @JsonKey(name: 'level')
+  num? level;
+
+  @JsonKey(name: 'folder_id')
+  num? folderId;
+
+  @JsonKey(name: 'folder_name')
+  String? folderName;
+
+  @JsonKey(name: 'team_id')
+  num? teamId;
+
+  @JsonKey(name: 'team_name')
+  String? teamName;
+
+  @JsonKey(name: 'created_at')
+  String? createdAt;
+
+  @JsonKey(name: 'last_open')
+  String? lastOpen;
+
+  @JsonKey(name: 'deleted_at')
+  String? deletedAt;
+
+  WorkbookViewDto({
+    this.workbookId,
+    this.userId,
+    this.workbookName,
+    this.bookmark,
+    this.level,
+    this.folderId,
+    this.folderName,
+    this.teamId,
+    this.teamName,
+    this.createdAt,
+    this.lastOpen,
+    this.deletedAt
+  });
+
+  factory WorkbookViewDto.fromJson(Map<String, dynamic> json) =>
+      _$WorkbookViewDtoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$WorkbookViewDtoToJson(this);
+}

--- a/lib/dashboard/data/mapper/workbook_mapper.dart
+++ b/lib/dashboard/data/mapper/workbook_mapper.dart
@@ -1,7 +1,10 @@
-import 'package:mongo_ai/dashboard/data/dto/workbook_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_view_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_table_dto.dart';
 import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 
-extension WorkbookMapper on WorkbookDto {
+// DB에서 가져올 때는 WorkbookDto 형태로 가져옴.
+// View에서 userName, folderName, teamName가 포함된 형태로 가져옴.
+extension WorkbookMapper on WorkbookViewDto {
   Workbook toWorkbook() {
     return Workbook(
       // non-nullable
@@ -20,6 +23,25 @@ extension WorkbookMapper on WorkbookDto {
       folderName: folderName,
       lastOpen: lastOpen != null ? DateTime.parse(lastOpen!) : null,
       deletedAt: deletedAt != null ? DateTime.parse(deletedAt!) : null,
+    );
+  }
+}
+
+// DB로 보낼 때는 WorkbookTableDto 형태로 보냄.
+// userName, folderName, teamName은 View에만 있고, Workbook 테이블에는 없음.
+extension WorkbookDtoMapper on Workbook {
+  WorkbookTableDto toWorkbookTableDto() {
+    return WorkbookTableDto(
+      workbookId: workbookId,
+      userId: userId,
+      workbookName: workbookName,   // not null
+      bookmark: bookmark,
+      level: level,
+      folderId: folderId,
+      teamId: teamId,               // not null
+      createdAt: createdAt.toIso8601String(),
+      lastOpen: lastOpen?.toIso8601String(),
+      deletedAt: deletedAt?.toIso8601String(),
     );
   }
 }

--- a/lib/dashboard/data/repository/workbook_repository_impl.dart
+++ b/lib/dashboard/data/repository/workbook_repository_impl.dart
@@ -1,6 +1,8 @@
 import 'package:mongo_ai/core/exception/app_exception.dart';
 import 'package:mongo_ai/core/result/result.dart';
 import 'package:mongo_ai/dashboard/data/data_source/workbook_data_source.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_view_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_table_dto.dart';
 import 'package:mongo_ai/dashboard/data/mapper/workbook_mapper.dart';
 import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 import 'package:mongo_ai/dashboard/domain/repository/workbook_repository.dart';
@@ -24,6 +26,56 @@ class WorkbookRepositoryImpl implements WorkbookRepository {
           message: '문제집 정보를 가져오는 중 오류가 발생했습니다.',
           error: e,
           stackTrace: StackTrace.current,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<Result<Workbook, AppException>> createWorkbook(WorkbookTableDto workbookTemplate) async {
+    try {
+      final workbookDto = await _dataSource.createWorkbook(workbookTemplate);
+      final workbook = workbookDto.toWorkbook();
+      return Result.success(workbook);
+    } catch (e, st) {
+      return Result.error(
+        AppException.remoteDataBase(
+          message: '문제집 생성 중 오류가 발생했습니다.',
+          error: e,
+          stackTrace: st,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<Result<Workbook, AppException>> updateWorkbook(Workbook workbook) async {
+    try {
+      final workbookTableDto = workbook.toWorkbookTableDto();
+      await _dataSource.updateWorkbook(workbookTableDto);
+      return Result.success(workbook);
+    } catch (e, st) {
+      return Result.error(
+        AppException.remoteDataBase(
+          message: '문제집 수정 중 오류가 발생했습니다.',
+          error: e,
+          stackTrace: st,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<Result<Workbook, AppException>> deleteWorkbook(Workbook workbook) async {
+    try {
+      await _dataSource.deleteWorkbook(workbook.workbookId);
+      return Result.success(workbook);
+    } catch (e, st) {
+      return Result.error(
+        AppException.remoteDataBase(
+          message: '문제집 삭제 중 오류가 발생했습니다.',
+          error: e,
+          stackTrace: st,
         ),
       );
     }

--- a/lib/dashboard/domain/repository/workbook_repository.dart
+++ b/lib/dashboard/domain/repository/workbook_repository.dart
@@ -1,7 +1,12 @@
 import 'package:mongo_ai/core/exception/app_exception.dart';
 import 'package:mongo_ai/core/result/result.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_view_dto.dart';
+import 'package:mongo_ai/dashboard/data/dto/workbook_table_dto.dart';
 import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 
 abstract interface class WorkbookRepository {
   Future<Result<List<Workbook>, AppException>> getWorkbooksByCurrentTeamId(int teamId);
+  Future<Result<Workbook, AppException>> createWorkbook(WorkbookTableDto workbookTableDto);
+  Future<Result<Workbook, AppException>> updateWorkbook(Workbook workbook);
+  Future<Result<Workbook, AppException>> deleteWorkbook(Workbook workbook);
 }

--- a/lib/dashboard/domain/use_case/delete_workbook_use_case.dart
+++ b/lib/dashboard/domain/use_case/delete_workbook_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:mongo_ai/core/exception/app_exception.dart';
+import 'package:mongo_ai/core/result/result.dart';
+import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
+import 'package:mongo_ai/dashboard/domain/repository/workbook_repository.dart';
+
+class DeleteWorkbookUseCase {
+  final WorkbookRepository _workbookRepository;
+
+  DeleteWorkbookUseCase(this._workbookRepository);
+
+  Future<Result<Workbook, AppException>> execute(Workbook workbook) async {
+    final result = await _workbookRepository.deleteWorkbook(workbook);
+    return result;
+  }
+}

--- a/lib/dashboard/domain/use_case/toggle_bookmark_use_case.dart
+++ b/lib/dashboard/domain/use_case/toggle_bookmark_use_case.dart
@@ -1,0 +1,18 @@
+import 'package:mongo_ai/core/exception/app_exception.dart';
+import 'package:mongo_ai/core/result/result.dart';
+import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
+import 'package:mongo_ai/dashboard/domain/repository/workbook_repository.dart';
+
+class ToggleBookmarkUseCase {
+  final WorkbookRepository workbookRepository;
+
+  ToggleBookmarkUseCase(this.workbookRepository);
+
+  Future<Result<Workbook, AppException>> execute(Workbook workbook) async {
+    final updatedWorkbook = workbook.copyWith(
+      bookmark: !workbook.bookmark,
+    );
+    final result = await workbookRepository.updateWorkbook(updatedWorkbook);
+    return result;
+  }
+}

--- a/lib/dashboard/domain/use_case/update_workbook_use_case.dart
+++ b/lib/dashboard/domain/use_case/update_workbook_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:mongo_ai/core/exception/app_exception.dart';
+import 'package:mongo_ai/core/result/result.dart';
+import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
+import 'package:mongo_ai/dashboard/domain/repository/workbook_repository.dart';
+
+class UpdateWorkbookUseCase {
+  final WorkbookRepository _workbookRepository;
+
+  UpdateWorkbookUseCase(this._workbookRepository);
+
+  Future<Result<Workbook, AppException>> execute(Workbook workbook) async {
+    final result = await _workbookRepository.updateWorkbook(workbook);
+    return result;
+  }
+}

--- a/lib/dashboard/presentation/component/folder_list_widget.dart
+++ b/lib/dashboard/presentation/component/folder_list_widget.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import 'package:mongo_ai/core/di/providers.dart';
@@ -32,6 +34,7 @@ class FolderListWidget extends ConsumerStatefulWidget {
 class _FolderListWidgetState extends ConsumerState<FolderListWidget> {
   final _createController = TextEditingController();
   final _editController = TextEditingController();
+  final MenuController _menuController = MenuController();
   late final FocusNode _createFocusNode;
   late final FocusNode _editFocusNode;
 
@@ -41,6 +44,10 @@ class _FolderListWidgetState extends ConsumerState<FolderListWidget> {
   @override
   void initState() {
     super.initState();
+    if (kIsWeb) {
+      // 브라우저 기본 메뉴 비활성화
+      BrowserContextMenu.disableContextMenu();
+    }
     // unfocus 시키면 폴더 생성 취소
     _createFocusNode = FocusNode()
       ..addListener(() {
@@ -200,7 +207,10 @@ class _FolderListWidgetState extends ConsumerState<FolderListWidget> {
                       } else {
                         // -------------------
                         // 폴더 리스트 UI
+                        // 각 항목마다 MenuController를 생성해야 정확한 위치 리턴 가능.
+                        final controller = MenuController();
                         return MenuAnchor(
+                          controller: controller,
                           menuChildren: [
                               MenuItemButton(
                                 onPressed: () {
@@ -225,25 +235,30 @@ class _FolderListWidgetState extends ConsumerState<FolderListWidget> {
                               backgroundColor: WidgetStateProperty.all(AppColor.white),
                           ),
                           builder: (context, controller, child) {
-                            return ListTile(
-                              title: Text(
-                                folder.folderName,
-                                style: AppTextStyle.bodyRegular.copyWith(
+                            return GestureDetector(
+                              onSecondaryTapDown: (details) {
+                                controller.open(position: details.localPosition);
+                              },
+                              onLongPressStart: (details) {
+                                controller.open(position: details.localPosition);
+                              },
+                              child: ListTile(
+                                title: Text(
+                                  folder.folderName,
+                                  style: AppTextStyle.bodyRegular.copyWith(
+                                    color: selected ? AppColor.primary : AppColor.mediumGray,
+                                  ),
+                                ),
+                                tileColor: selected ? AppColor.paleBlue : AppColor.white,
+                                leading: Icon(
+                                  Icons.folder,
                                   color: selected ? AppColor.primary : AppColor.mediumGray,
                                 ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                                onTap: () => widget.onClickFolder(folder),
                               ),
-                              tileColor: selected ? AppColor.paleBlue : AppColor.white,
-                              leading: Icon(
-                                Icons.folder,
-                                color: selected ? AppColor.primary : AppColor.mediumGray,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              onTap: () => widget.onClickFolder(folder),
-                              onLongPress: () {
-                                controller.open();
-                              },
                             );
                           }
                         );

--- a/lib/dashboard/presentation/component/workbook_grid_item.dart
+++ b/lib/dashboard/presentation/component/workbook_grid_item.dart
@@ -10,7 +10,7 @@ import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 class WorkbookGridItem extends ConsumerWidget {
   final void Function() onClick;
   final void Function(Workbook workbook) onSelect;
-  final void Function() onBookmark;
+  final void Function(Workbook workbook) onBookmark;
   final Workbook workbook;
 
   const WorkbookGridItem({
@@ -87,7 +87,7 @@ class WorkbookGridItem extends ConsumerWidget {
                                 alignment: Alignment.topRight,
                                 child: GestureDetector(
                                   behavior: HitTestBehavior.translucent,
-                                  onTap: onBookmark,
+                                  onTap: () => onBookmark(workbook),
                                   child: Icon(
                                     workbook.bookmark
                                         ? Icons.star

--- a/lib/dashboard/presentation/component/workbook_grid_item.dart
+++ b/lib/dashboard/presentation/component/workbook_grid_item.dart
@@ -11,6 +11,8 @@ class WorkbookGridItem extends ConsumerWidget {
   final void Function() onClick;
   final void Function(Workbook workbook) onSelect;
   final void Function(Workbook workbook) onBookmark;
+  final void Function(Workbook workbook) onDelete;
+  final void Function(Workbook workbook) onEdit;
   final Workbook workbook;
 
   const WorkbookGridItem({
@@ -19,144 +21,182 @@ class WorkbookGridItem extends ConsumerWidget {
     required this.onClick,
     required this.onSelect,
     required this.onBookmark,
+    required this.onDelete,
+    required this.onEdit,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final controller = MenuController();
     final isSelected = ref
         .watch(selectedWorkbookStateProvider)
         .selectedWorkbooks
         .contains(workbook);
     final isSelectMode = ref.watch(selectedWorkbookStateProvider).isSelectMode;
-    return GestureDetector(
-      onTap: () {
-        if (isSelectMode) {
-          onSelect(workbook);
-        } else {
-          onClick();
-        }
-      },
-      child: Container(
-        width: 250,
-        decoration: BoxDecoration(
-          boxShadow: [
-            BoxShadow(
-              color: AppColor.deepBlack.withAlpha(50),
-              blurRadius: 5,
-              offset: const Offset(0, 2),
-            ),
-          ],
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(
-            color: isSelected ? AppColor.primary : Colors.transparent,
-            width: 2,
-          ),
+    return MenuAnchor(
+      controller: controller,
+      menuChildren: [
+        MenuItemButton(
+          onPressed: () {
+            onEdit(workbook);
+          },
+          leadingIcon: const Icon(Icons.edit),
+          child: const Text('문제집 수정하기'),
         ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(10),
-          child: Container(
-            color: AppColor.white,
-            child: Column(
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.all(20.0),
-                    child: Column(
-                      children: [
-                        SizedBox(
-                          height: 45,
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: Align(
-                                  alignment: Alignment.topLeft,
-                                  child: Text(
-                                    workbook.workbookName,
-                                    maxLines: 2,
-                                    overflow: TextOverflow.ellipsis, // 넘칠 때 “…”
-                                    softWrap: true, // 줄바꿈 허용
-                                    style: AppTextStyle.bodyMedium.copyWith(
-                                      color: AppColor.deepBlack,
-                                      fontWeight: FontWeight.bold,
+        MenuItemButton(
+          onPressed: () {
+            onDelete(workbook);
+          },
+          leadingIcon: const Icon(Icons.delete),
+          child: const Text('문제집 삭제하기'),
+        ),
+      ],
+      style: MenuStyle(
+        backgroundColor: WidgetStateProperty.all(AppColor.white),
+      ),
+      child: GestureDetector(
+        onTap: () {
+          if (isSelectMode) {
+            onSelect(workbook);
+          } else {
+            onClick();
+          }
+        },
+        onSecondaryTapDown: (details) {
+          if (isSelectMode) {
+            onSelect(workbook);
+          } else {
+            controller.open(position: details.localPosition);
+          }
+        },
+        child: Container(
+          width: 250,
+          decoration: BoxDecoration(
+            boxShadow: [
+              BoxShadow(
+                color: AppColor.deepBlack.withAlpha(50),
+                blurRadius: 5,
+                offset: const Offset(0, 2),
+              ),
+            ],
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: isSelected ? AppColor.primary : Colors.transparent,
+              width: 2,
+            ),
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: Container(
+              color: AppColor.white,
+              child: Column(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(20.0),
+                      child: Column(
+                        children: [
+                          SizedBox(
+                            height: 45,
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Align(
+                                    alignment: Alignment.topLeft,
+                                    child: Text(
+                                      workbook.workbookName,
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis, // 넘칠 때 “…”
+                                      softWrap: true, // 줄바꿈 허용
+                                      style: AppTextStyle.bodyMedium.copyWith(
+                                        color: AppColor.deepBlack,
+                                        fontWeight: FontWeight.bold,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              const Gap(10),
-                              Align(
-                                alignment: Alignment.topRight,
-                                child: GestureDetector(
-                                  behavior: HitTestBehavior.translucent,
-                                  onTap: () => onBookmark(workbook),
-                                  child: Icon(
-                                    workbook.bookmark
-                                        ? Icons.star
-                                        : Icons.star_border,
-                                    size: 24,
-                                    color:
-                                        workbook.bookmark
-                                            ? AppColor.secondary
-                                            : AppColor.paleGray,
+                                const Gap(10),
+                                Align(
+                                  alignment: Alignment.topRight,
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.translucent,
+                                    onTap: () {
+                                      if(isSelectMode) {
+                                        onSelect(workbook);
+                                      } else {
+                                        onBookmark(workbook);
+                                      }
+                                    },
+                                    child: Icon(
+                                      workbook.bookmark
+                                          ? Icons.star
+                                          : Icons.star_border,
+                                      size: 24,
+                                      color:
+                                          workbook.bookmark
+                                              ? AppColor.secondary
+                                              : AppColor.paleGray,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
-                        ),
-                        Expanded(
-                          child: Column(
-                            children: [
-                              const Spacer(),
-                              _gridTile(
-                                Icons.person,
-                                workbook.userName ?? 'Unknown',
-                              ),
-                              const Gap(10),
-                              _gridTile(Icons.groups, workbook.teamName),
-                              const Gap(10),
-                              _gridTile(
-                                Icons.folder,
-                                workbook.folderName.toString(),
-                              ),
-                              const Spacer(),
-                            ],
+                          Expanded(
+                            child: Column(
+                              children: [
+                                const Spacer(),
+                                _gridTile(
+                                  Icons.person,
+                                  workbook.userName ?? 'Unknown',
+                                ),
+                                const Gap(10),
+                                _gridTile(Icons.groups, workbook.teamName),
+                                const Gap(10),
+                                _gridTile(
+                                  Icons.folder,
+                                  workbook.folderName.toString(),
+                                ),
+                                const Spacer(),
+                              ],
+                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                Container(
-                  decoration: BoxDecoration(
-                    color: AppColor.paleBlue,
-                    border: Border(
-                      top: BorderSide(
-                        color:
-                            isSelected
-                                ? AppColor.primary
-                                : AppColor.lightGrayBorder,
-                        width: 2,
+                        ],
                       ),
                     ),
                   ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 10,
-                    ),
-                    child: Row(
-                      children: [
-                        const Text('수정 : '),
-                        Text(
-                          DateFormat(
-                            'yyyy-MM-dd HH:mm',
-                          ).format(workbook.createdAt),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: AppColor.paleBlue,
+                      border: Border(
+                        top: BorderSide(
+                          color:
+                              isSelected
+                                  ? AppColor.primary
+                                  : AppColor.lightGrayBorder,
+                          width: 2,
                         ),
-                      ],
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 10,
+                      ),
+                      child: Row(
+                        children: [
+                          const Text('수정 : '),
+                          Text(
+                            DateFormat(
+                              'yyyy-MM-dd HH:mm',
+                            ).format(workbook.createdAt),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/dashboard/presentation/component/workbook_list_item.dart
+++ b/lib/dashboard/presentation/component/workbook_list_item.dart
@@ -9,7 +9,7 @@ import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 class WorkbookListItem extends ConsumerWidget {
   final void Function() onClick;
   final void Function(Workbook workbook) onSelect;
-  final void Function() onBookmark;
+  final void Function(Workbook workbook) onBookmark;
   final Workbook workbook;
 
   const WorkbookListItem({
@@ -68,7 +68,13 @@ class WorkbookListItem extends ConsumerWidget {
                         workbook.bookmark == true
                             ? const Icon(Icons.star, color: AppColor.secondary)
                             : const Icon(Icons.star_border),
-                    onPressed: () => onBookmark(),
+                    onPressed: () {
+                      if(isSelectMode) {
+                        onSelect(workbook);
+                      } else {
+                        onBookmark(workbook);
+                      }
+                    }
                   ),
                 ],
               ),

--- a/lib/dashboard/presentation/dashboard_screen.dart
+++ b/lib/dashboard/presentation/dashboard_screen.dart
@@ -173,6 +173,22 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
               child: Center(
                 child: Row(
                   children: [
+                    Container(
+                      width: 30,
+                      height: 30,
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: AppColor.primary,
+                      ),
+                      child: Center(
+                        child: Image.asset(
+                          'images/mongo_ai_logo.png',
+                          width: 16,
+                          height: 16,
+                        ),
+                      ),
+                    ),
+                    const Gap(10),
                     Text(
                       'Mongo AI',
                       style: AppTextStyle.titleBold.copyWith(

--- a/lib/dashboard/presentation/deleted_files/deleted_files_screen.dart
+++ b/lib/dashboard/presentation/deleted_files/deleted_files_screen.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class DeletedFilesScreen extends StatelessWidget {
+class DeletedFilesScreen extends ConsumerWidget {
   const DeletedFilesScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return const Placeholder();
   }
 }

--- a/lib/dashboard/presentation/folder/controller/folder_view_model.dart
+++ b/lib/dashboard/presentation/folder/controller/folder_view_model.dart
@@ -7,7 +7,6 @@ import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 import 'package:mongo_ai/dashboard/presentation/folder/controller/folder_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-
 part 'folder_view_model.g.dart';
 
 @riverpod
@@ -35,11 +34,28 @@ class FolderViewModel extends _$FolderViewModel {
     );
   }
 
+  // ------------------------
+  // 문서 병합모드 메서드
   Future<void> selectWorkbook(Workbook workbook) async {
     ref.read(selectedWorkbookStateProvider.notifier).selectWorkbook(workbook);
   }
 
+  // ------------------------
+  // Workbook DB 메서드
   Future<void> refreshWorkbookList() async {
     ref.refresh(getWorkbooksByCurrentTeamIdProvider);
+  }
+
+  Future<void> toggleBookmark(Workbook workbook) async {
+    final result = await ref.read(toggleBookmarkUseCaseProvider).execute(workbook);
+    switch(result) {
+      case Success(data: final data):
+        refreshWorkbookList();
+        break;
+      case Error():
+        print('Error: ${result.error}');
+        // 여기서 알림등 에러 처리 가능.
+        break;
+    }
   }
 }

--- a/lib/dashboard/presentation/folder/folder_screen.dart
+++ b/lib/dashboard/presentation/folder/folder_screen.dart
@@ -40,7 +40,15 @@ class FolderScreen extends ConsumerWidget {
             onSelect: (Workbook workbook) {
               viewModel.selectWorkbook(workbook);
             },
-            onBookmark: () {},
+            onBookmark: (Workbook workbook) {
+              viewModel.toggleBookmark(workbook);
+            },
+            onEdit: (Workbook workbook) {
+              print('Edit: ${workbook.workbookId}');
+            },
+            onDelete: (Workbook workbook) {
+              print('Delete: ${workbook.workbookId}');
+            },
           ),
         );
       }).toList(),
@@ -58,7 +66,9 @@ class FolderScreen extends ConsumerWidget {
           onSelect: (Workbook workbook) {
             viewModel.selectWorkbook(workbook);
           },
-          onBookmark: () {},
+          onBookmark: (Workbook workbook) {
+            viewModel.toggleBookmark(workbook);
+          },
         );
       },
       separatorBuilder: (context, index) {

--- a/lib/dashboard/presentation/recent_files/controller/recent_files_view_model.dart
+++ b/lib/dashboard/presentation/recent_files/controller/recent_files_view_model.dart
@@ -33,11 +33,54 @@ class RecentFilesViewModel extends _$RecentFilesViewModel {
     );
   }
 
+  // ------------------------
+  // 문서 병합모드 메서드
   Future<void> selectWorkbook(Workbook workbook) async {
     ref.read(selectedWorkbookStateProvider.notifier).selectWorkbook(workbook);
   }
 
+  // ------------------------
+  // Workbook DB 메서드
   Future<void> refreshWorkbookList() async {
     ref.refresh(getWorkbooksByCurrentTeamIdProvider);
+  }
+
+  Future<void> toggleBookmark(Workbook workbook) async {
+    final result = await ref.read(toggleBookmarkUseCaseProvider).execute(workbook);
+    switch(result) {
+      case Success(data: final data):
+        refreshWorkbookList();
+        break;
+      case Error():
+        print('Error: ${result.error}');
+        // 여기서 알림등 에러 처리 가능.
+        break;
+    }
+  }
+
+  // Future<void> updateWorkbook(Workbook workbook) async {
+  //   final result = await ref.read(updateWorkbookUseCaseProvider).execute(workbook);
+  //   switch(result) {
+  //     case Success(data: final data):
+  //       refreshWorkbookList();
+  //       break;
+  //     case Error():
+  //       print('Error: ${result.error}');
+  //       // 여기서 알림등 에러 처리 가능.
+  //       break;
+  //   }
+  // }
+
+  Future<void> deleteWorkbook(Workbook workbook) async {
+    final result = await ref.read(deleteWorkbookUseCaseProvider).execute(workbook);
+    switch(result) {
+      case Success(data: final data):
+        refreshWorkbookList();
+        break;
+      case Error():
+        print('Error: ${result.error}');
+        // 여기서 알림등 에러 처리 가능.
+        break;
+    }
   }
 }

--- a/lib/dashboard/presentation/recent_files/recent_files_screen.dart
+++ b/lib/dashboard/presentation/recent_files/recent_files_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongo_ai/core/style/app_color.dart';
 import 'package:mongo_ai/dashboard/domain/model/workbook.dart';
 import 'package:mongo_ai/dashboard/presentation/component/workbook_grid_item.dart';
 import 'package:mongo_ai/dashboard/presentation/component/workbook_list_item.dart';
@@ -40,7 +41,15 @@ class RecentFilesScreen extends ConsumerWidget {
             onSelect: (Workbook workbook) {
               viewModel.selectWorkbook(workbook);
             },
-            onBookmark: () {},
+            onBookmark: (Workbook workbook) {
+              viewModel.toggleBookmark(workbook);
+            },
+            onEdit: (Workbook workbook) {
+              print('Edit: ${workbook.workbookId}');
+            },
+            onDelete: (Workbook workbook) {
+              print('Delete: ${workbook.workbookId}');
+            },
           ),
         );
       }).toList(),
@@ -58,12 +67,49 @@ class RecentFilesScreen extends ConsumerWidget {
           onSelect: (Workbook workbook) {
             viewModel.selectWorkbook(workbook);
           },
-          onBookmark: () {},
+          onBookmark: (Workbook workbook) {
+            viewModel.toggleBookmark(workbook);
+          },
         );
       },
       separatorBuilder: (context, index) {
         return const SizedBox(height: 10);
       },
+    );
+  }
+
+  void _showEditDialog(BuildContext context, Workbook workbook) {
+    final controller = TextEditingController(text: workbook.workbookName);
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColor.white,
+        title: const Text('문제집 수정하기'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            labelText: '문제집 이름',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              controller.dispose();
+            },
+            child: const Text('취소'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              Navigator.of(ctx).pop();
+              controller.dispose();
+            },
+            child: const Text('확인'),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## 🔍 변경사항 요약
- Workbook CRUD를 위한 Repository, DataSource 메서드를 추가했습니다.
- Workbook Dto가 read를 위한 WorkbookViewDto와 DB 업로드를 위한 WorkbookTableDto로 분리되었습니다.
- 간단한 우클릭 MenuAnchor가 추가되었습니다.

## 📌 리뷰사항
- 특별한 리뷰사항은 없습니다.

## ✅ 체크리스트
- [x] Workbook CRUD 추가
- [x] Workbook Dto 개편
- [x] 우클릭 상호작용 추가

## 📝 추가 참고사항 (선택)
- 테스트 방법, 고려사항, 관련 자료 등이 있다면 자유롭게 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 워크북의 즐겨찾기 토글, 수정, 삭제 기능이 추가되었습니다.
  - 워크북 그리드 및 리스트 항목에서 마우스 오른쪽 클릭 시 컨텍스트 메뉴(수정/삭제 등) 지원이 추가되었습니다.
  - 워크북 이름 편집 다이얼로그가 추가되었습니다.
  - 사이드바 헤더에 Mongo AI 로고가 추가되었습니다.

- **버그 수정**
  - 즐겨찾기 버튼이 선택 모드와 일반 모드에서 각각 다르게 동작하도록 개선되었습니다.

- **UI/UX 개선**
  - 폴더 및 워크북 리스트에서 컨텍스트 메뉴와 상호작용이 향상되었습니다.

- **기타**
  - 내부 데이터 구조 및 콜백 시그니처가 일부 변경되어 향후 워크북 관련 기능 확장에 대비하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->