### PR TITLE
feat/개인정보처리방침 구현, 프로필 이름 안바뀌는 문제 해결, README.md 재작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,116 +1,119 @@
-# 영어학원 앱 (가칭) 📱
+# MongoAI 프로젝트 📚✨
+
+<div align="center">
+  <img src="https://img.shields.io/badge/Supabase-DB-3ECF8E?logo=supabase" alt="Supabase" />
+  <img src="https://img.shields.io/badge/Status-Active-success" alt="Project Status" />
+</div>
+<div align="center">
+  <a href="https://gitflow-exercise.github.io/MongoAI-web/" target="_blank" style="
+     display: inline-block;
+     background-color: #6C63FF;
+     color: white;
+     padding: 10px 20px;
+     margin-top: 10px;
+     border-radius: 8px;
+     text-decoration: none;
+     font-weight: bold;
+     box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+     transition: background-color 0.3s ease;
+  " onmouseover="this.style.backgroundColor='#2bb67c'" onmouseout="this.style.backgroundColor='#3ECF8E'">
+    Mongo AI 바로가기 🚀
+  </a>
+</div>
 
 ## 프로젝트 소개 🚀
 
-영어학원 관리 및 학습 지원을 위한 모바일 애플리케이션입니다.
+기업 프로젝트 일환으로 MongoAI는 교사를 위한 AI 기반 문제집 생성 도구입니다. 교사들이 텍스트, 이미지, PDF에서 문제를 자동으로 생성하고, 맞춤형 문제집을 즉시 제작할 수 있도록 도와줍니다. 팀 협업 기능을 통해 교사들이 문제집을 공유하고 함께 작업할 수 있습니다.
+
+### 왜 MongoAI인가요? 🤔
+
+교사들은 평균적으로 주당 10-15시간을 교육 자료 준비에 사용합니다. MongoAI는 이 시간을 획기적으로 단축시켜 교사들이 학생 지도에 더 집중할 수 있도록 합니다. 단 몇 분 만에 다양한 유형의 문제를 생성하고 커스터마이징할 수 있습니다.
 
 ## 주요 기능 ✨
 
-- 회원 관리
-- 수업 일정 관리
-- 학습 자료 제공
-- 진도 관리
-- 알림 서비스
+- **AI 기반 문제 생성** - 텍스트, 이미지, PDF에서 자동으로 문제 생성
+- **맞춤형 PDF 문제집** - 즉시 다운로드 가능한 문제집 제작
+- **팀 협업 시스템** - 팀원들과 문제집 공유 및 공동 작업
+- **폴더 관리** - 체계적인 문제집 분류 및 관리
+- **북마크 기능** - 중요한 문제집 표시 및 빠른 접근
+- **휴지통 기능** - 삭제된 문제집 복원 가능. Supabase crob job 활용
+
+## 개발 팀 소개 👨‍💻👩‍💻
+
+| 팀원   | 역할                      | github profile                              |
+| ------ | ------------------------- | ------------------------------------------- |
+| 김옥현 | 사용자 인증, 디자인, 기획 | [okstring](https://github.com/okstring)     |
+| 임명우 | (추가, 수정 예정)         | [Dansot4891](https://github.com/Dansot4891) |
+| 최지민 | (추가, 수정 예정)         | [irmu98](https://github.com/irmu98)         |
+| 허준호 | (추가, 수정 예정)         | [helljh](https://github.com/helljh)         |
+
+
 
 ## 기술 스택 🛠️
 
-- **상태 관리**: Riverpod
-- **라우팅**: Go_Router
-- **로컬 저장소**: Hive
-- **백엔드/클라우드**: Supabase ⚡
-    - Auth (인증)
-    - PostgreSQL 데이터베이스
+### 프론트엔드
 
+- **Riverpod**: 상태 관리
+- **Go_Router**: 라우팅
+- **Freezed**: 불변 객체 생성
 
+### 백엔드
 
-## Dart, Flutter 스타일 규칙 ⚠️
+- **Supabase**: 서버리스 백엔드 플랫폼
+  - Auth: 사용자 인증
+  - PostgreSQL: 데이터베이스
+  - Storage: 파일 저장
+  - Edge Functions: 서버리스 함수
+- **Firebase**: Google Analytics 
 
-### 헬퍼 메소드 지양
+### 개발 도구
 
-- 기능적인 로직을 단순 메소드로 빼는 것을 지양합니다.
-  - **최대한 위젯 단위로 분리**하여 재사용성과 가독성을 높입니다.
+- **Git & GitHub**: 버전 관리 및 협업
 
-### const Lint 적용
+- **GitHub Actions**: CI/CD
 
-- const lint 적용으로 메모리 성능 최적화
+- **Figma**: UI/UX 디자인 - [Figma 디자인 바로가기](https://www.figma.com/design/XqEZ6dBUOKMbyUnnLNENFP/Mongo-AI-%EC%9E%90%EC%B2%B4-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=0-1&t=5eBEk9YAAfiydj2h-1)
 
-
+  [![스크린샷 2025-05-20 오후 3.36.36](/Users/okstring/Documents/image/스크린샷 2025-05-20 오후 3.36.36.png)](https://www.figma.com/design/XqEZ6dBUOKMbyUnnLNENFP/Mongo-AI-%EC%9E%90%EC%B2%B4-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=0-1&t=5eBEk9YAAfiydj2h-1)
 
 ## 아키텍처 🏗️
 
-MVI + MVVM, Clean Architecture 패턴을 사용합니다.
+MongoAI는 MVI + MVVM, Clean Architecture 패턴을 사용합니다. 이를 통해 확장성, 테스트 용이성, 코드 품질을 보장합니다.
 
 ```
 lib/
-├── core/
-│   ├── routing/
-│   ├── ui/
-│   └── util/
-├── auth/
-│   └── login/
-│       ├── data/
-│       ├── domain/
-│       └── presentation/
+├── core/                 # 공통 기능 및 유틸리티
+│   ├── component/        # 재사용 가능한 UI 컴포넌트
+│   ├── constants/        # 앱 전체에서 사용되는 상수
+│   ├── di/               # 의존성 주입
+│   ├── enum/             # 열거형 정의
+│   ├── extension/        # 확장 메서드
+│   ├── result/           # 결과 처리 래퍼
+│   ├── routing/          # 라우팅 설정
+│   ├── state/            # 전역 상태 관리
+│   ├── style/            # 스타일 정의
+│   └── utils/            # 유틸리티 함수
+├── auth/                 # 인증 관련 기능
+│   ├── data/             # 데이터 레이어
+│   ├── domain/           # 도메인 레이어
+│   └── presentation/     # 프레젠테이션 레이어
+├── dashboard/            # 대시보드 기능
+...
+├── create/               # 문제 생성 기능
+...
+└── landing/              # 랜딩 페이지 및 마케팅
+...
 ```
 
-### Dart 클래스 작성 순서
+### Clean Architecture
 
-- **필드** → **게터/세터** → **생성자** → **오버라이드 메소드** 순으로 작성합니다.
-
-
-
-### Presentation 폴더 구조
-
-`$NAME$Screen.dart`
-
-- 각 화면별 UI 컴포넌트를 정의하는 폴더입니다.
-
-$NAME$`ScreenRoot.dart`
-
--  화면 진입 지점을 정의하는 폴더입니다.
-
-`Controller/`
-
-- 각 화면과 연결되는 로직을 관리하는 폴더입니다.
-- 내부 구성:
-  -  $NAME$`ViewModel` : 화면 상태 관리 및 비즈니스 로직 처리
-  -  $NAME$`State` : ViewModel이 관리하는 상태 정의
-  - $NAME$`Action` : 화면에서 발생하는 사용자 액션 정의
-  - $NAME$`Event` : 외부에서 발생하여 ViewModel이 수신하는 이벤트 정의
-
-
-
-## 개발 프로세스 🔄
-
-1. GitHub Issue 생성
-2. 해당 이슈에 맞는 브랜치 생성
-3. 작업 수행 및 커밋
-4. PR 생성 및 이슈 연결
-5. 코드 리뷰
-6. Merge
-
-## 브랜치 전략 🌿
-
-- Git Flow 사용
-- 브랜치 네이밍 규칙:
-    - `feature/` - 새로운 기능 개발
-    - `fix/` - 버그 수정
-    - `hotfix/` - 긴급 버그 수정
-    - `chore/` - 빌드 스크립트, 설정 등 기타 작업
-    - `docs/` - 문서 수정
-    - `style/` - 코드 스타일 변경
-
-## Pull Request 규칙 📝
-
-- 리뷰 최소 1명 이상 승인 필요
-- Issue와 반드시 연결 (PR 등록 후 연결)
-- `feature` - PR - issue는 1:1:1 관계 유지
-
-## 프로젝트 보드 활용 📊
-
-- 이슈는 반드시 프로젝트 보드에 등록
-- 칸반 보드 형식으로 관리 (Todo, In Progress, Review, Done)
-
+```mermaid
+graph TD
+    A[UI Layer] --> B[Presentation Layer]
+    B --> C[Domain Layer]
+    C --> D[Data Layer]
+    D --> E[External Data Sources]
+```
 
 ### MVI 패턴 구성요소
 
@@ -119,8 +122,60 @@ $NAME$`ScreenRoot.dart`
 - **Event**: 일회성 이벤트 정의 (스낵바, 다이얼로그 등)
 - **ViewModel**: 상태 관리 및 비즈니스 로직 처리
 - **Screen**: UI 구성 요소 및 레이아웃
-- **ScreenRoot**: 화면 진입점, ViewModel 연결 및 이벤트 처리
+- **ScreenRoot**: 화면 진입점, ViewModel 연결 및 이벤트, 액션 처리
 
-## 더 자세한 정보 📚
+## 코드 컨벤션 📐
 
-프로젝트 개발에 관한 더 자세한 정보는 [Wiki](https://github.com/GitFlow-Exercise/Flutter-Memo-App/wiki)를 참조해주세요.
+### 스타일 규칙
+
+- **const Lint**: const 선언을 최대한 활용하여 메모리 성능 최적화
+- **위젯 분리**: 기능적인 로직을 단순 메소드가 아닌 위젯 단위로 분리하여 재사용성과 가독성 향상
+- **하드코딩 방지**: 색상 및 텍스트 스타일은 `AppColor`, `AppTextStyle` 상수 사용
+
+## 개발 프로세스 🔄
+
+MongoAI 팀은 애자일 방법론을 따르며, 다음과 같은 개발 프로세스를 사용합니다:
+
+1. **이슈 생성**: 새로운 기능, 버그 수정 등을 GitHub 이슈로 등록
+2. **브랜치 생성**: 해당 이슈에 맞는 브랜치 생성 (네이밍 규칙 준수)
+3. **개발 작업**: 코드 작성 및 테스트 수행
+4. **PR 생성**: 작업 완료 후 Pull Request 생성 및 이슈 연결
+5. **코드 리뷰**: 최소 1명 이상의 팀원이 코드를 리뷰하고 승인
+6. **Merge**: 코드 리뷰 통과 후 develop 브랜치에 병합
+7. **배포**: main 브랜치에 Push시 CI/CD 파이프라인을 통한 자동 배포
+
+## 브랜치 전략 🌿
+
+Git Flow 전략을 기반으로 한 브랜치 전략을 사용합니다:
+
+- `main`: 제품 릴리스 버전, 항상 안정적인 상태 유지
+- `develop`: 개발 중인 코드의 통합 브랜치
+- `feature/<feature-name>`: 새로운 기능 개발
+- `fix/<issue-number>`: 버그 수정
+- `hotfix/<issue-number>`: 긴급 버그 수정
+- `chore/<task-name>`: 빌드 스크립트, 환경 설정 등 기타 작업
+- `docs/<document-name>`: 문서 추가 또는 수정
+- `style/<component-name>`: UI 스타일 변경 작업
+
+
+
+## 팀 문화 👥
+
+MongoAI 팀은 다음과 같은 문화를 가지고 있습니다:
+
+- **데일리 스크럼**: 매일 평일 업무시작 전 회고, 현재상황 공유를 통해 추후 개선점 도출
+- **페어 프로그래밍**: 복잡한 기능 개발 시 페어 프로그래밍 활용
+- **코드 리뷰 문화**: 모든 코드는 최소 1명 이상의 리뷰를 받음
+
+
+
+## 프로젝트 마일스톤 🏁
+
+- **1주차(2025. 05. 02~ 2025. 05. 12)**: 기업 프로젝트 차 미팅, 자체 기획 확정, 자체 디자인, 아키텍처 설계 및 기술 조사
+- **2주차(2025. 05. 13~ 2025. 05. 19)**: 디자인, 기획에 맞춰 개발 착수
+- **3주차(2025. 05. 20~ 2025. 05. 26)**: 추가 기능 구현, 리팩토링 및 시연 영상, 발표 준비
+- **2025. 05. 27**: 최종 발표
+
+------
+
+<div align="center">   <p><i>MongoAI - 교사의 시간을 절약하고, 교육의 질을 높이는 AI 동반자</i></p>   <p>Made with ❤️ by the MongoAI Team</p> </div>

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@
 
 - **Figma**: UI/UX 디자인 - [Figma 디자인 바로가기](https://www.figma.com/design/XqEZ6dBUOKMbyUnnLNENFP/Mongo-AI-%EC%9E%90%EC%B2%B4-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=0-1&t=5eBEk9YAAfiydj2h-1)
 
-  [![스크린샷 2025-05-20 오후 3.36.36](/Users/okstring/Documents/image/스크린샷 2025-05-20 오후 3.36.36.png)](https://www.figma.com/design/XqEZ6dBUOKMbyUnnLNENFP/Mongo-AI-%EC%9E%90%EC%B2%B4-%EB%94%94%EC%9E%90%EC%9D%B8?node-id=0-1&t=5eBEk9YAAfiydj2h-1)
-
 ## 아키텍처 🏗️
 
 MongoAI는 MVI + MVVM, Clean Architecture 패턴을 사용합니다. 이를 통해 확장성, 테스트 용이성, 코드 품질을 보장합니다.

--- a/lib/auth/presentation/sign_up_password/controller/sign_up_password_action.dart
+++ b/lib/auth/presentation/sign_up_password/controller/sign_up_password_action.dart
@@ -15,4 +15,6 @@ sealed class SignUpPasswordAction with _$SignUpPasswordAction {
       OnTapShowConfirmPassword;
 
   const factory SignUpPasswordAction.onTapLogin() = OnTapLogin;
+
+  const factory SignUpPasswordAction.onPressedPrivacyPolicies() = OnPressedPrivacyPolicies;
 }

--- a/lib/auth/presentation/sign_up_password/screen/sign_up_password_screen.dart
+++ b/lib/auth/presentation/sign_up_password/screen/sign_up_password_screen.dart
@@ -268,15 +268,48 @@ class _SignUpPasswordScreenState extends State<SignUpPasswordScreen> {
                                     const SignUpPasswordAction.onTapCheckPrivacyPolicy(),
                                   ),
                             ),
-                            const Expanded(
-                              child: Text(
-                                'Mongo AI의 개인정보처리방침 및 이용약관에 동의합니다.',
-                                style: TextStyle(
-                                  fontFamily: AppTextStyle.fontFamily,
-                                  fontSize: 12,
-                                  fontWeight: FontWeight.w400,
-                                  color: AppColor.black,
-                                ),
+                            Expanded(
+                              child: Row(
+                                children: [
+                                  const Text(
+                                    'Mongo AI의 ',
+                                    style: TextStyle(
+                                      fontFamily: AppTextStyle.fontFamily,
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w400,
+                                      color: AppColor.black,
+                                    ),
+                                  ),
+                                  TextButton(
+                                    onPressed: () {
+                                      widget.onAction(const SignUpPasswordAction.onPressedPrivacyPolicies());
+                                    },
+                                    style: TextButton.styleFrom(
+                                      padding: EdgeInsets.zero,
+                                      minimumSize: Size.zero,
+                                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                      overlayColor: Colors.transparent
+                                    ),
+                                    child: const Text(
+                                      '개인정보처리방침',
+                                      style: TextStyle(
+                                        fontFamily: AppTextStyle.fontFamily,
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.w400,
+                                        color: AppColor.landingIcon,
+                                      ),
+                                    ),
+                                  ),
+                                  const Text(
+                                    '에 동의합니다.',
+                                    style: TextStyle(
+                                      fontFamily: AppTextStyle.fontFamily,
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w400,
+                                      color: AppColor.black,
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
                           ],

--- a/lib/auth/presentation/sign_up_password/screen/sign_up_password_screen_root.dart
+++ b/lib/auth/presentation/sign_up_password/screen/sign_up_password_screen_root.dart
@@ -80,6 +80,8 @@ class _SignUpPasswordScreenRootState
       case SubmitForm():
         viewModel.submitForm();
         break;
+      case OnPressedPrivacyPolicies():
+        context.go(Routes.privacyPolicies);
     }
   }
 }

--- a/lib/core/constants/app_table_name.dart
+++ b/lib/core/constants/app_table_name.dart
@@ -8,4 +8,5 @@ abstract class AppTableName {
   static const String prompt = 'prompt';
   static const String userPrivate = 'userPrivate';
   static const String users = 'users';
+  static const String privacyPolicies = 'privacy_policies';
 }

--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -71,7 +71,7 @@ final userProfileRepositoryProvider = Provider<UserProfileRepository>((ref) {
 });
 
 final getCurrentUserProfileProvider =
-    FutureProvider<Result<UserProfile, AppException>>((ref) async {
+    FutureProvider.autoDispose<Result<UserProfile, AppException>>((ref) async {
       final repository = ref.watch(userProfileRepositoryProvider);
       return repository.getCurrentUserProfile();
     });

--- a/lib/core/di/providers.dart
+++ b/lib/core/di/providers.dart
@@ -50,6 +50,10 @@ import 'package:mongo_ai/dashboard/domain/repository/user_profile_repository.dar
 import 'package:mongo_ai/dashboard/domain/repository/workbook_repository.dart';
 import 'package:mongo_ai/dashboard/domain/use_case/delete_workbook_use_case.dart';
 import 'package:mongo_ai/dashboard/domain/use_case/toggle_bookmark_use_case.dart';
+import 'package:mongo_ai/landing/data/data_source/privacy_policies_data_source.dart';
+import 'package:mongo_ai/landing/data/data_source/privacy_policies_data_source_impl.dart';
+import 'package:mongo_ai/landing/data/repository/privacy_policies_repository_impl.dart';
+import 'package:mongo_ai/landing/domain/repository/privacy_policies_repository.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final supabaseClientProvider = Provider<SupabaseClient>((ref) {
@@ -239,4 +243,21 @@ final problemDataSourceProvider = Provider<ProblemDataSource>((ref) {
 final problemRepositoryProvider = Provider<ProblemRepository>((ref) {
   final dataSource = ref.watch(problemDataSourceProvider);
   return ProblemRepositoryImpl(dataSource: dataSource);
+});
+
+// -----------------------------------
+// landing
+// -----------------------------------
+// DataSource
+final privacyPoliciesDataSourceProvider = Provider<PrivacyPoliciesDataSource>((ref) {
+  final client = ref.watch(supabaseClientProvider);
+  return PrivacyPoliciesDataSourceImpl(client: client);
+});
+
+// -----------------------------------
+// Repository
+
+final privacyPoliciesRepositoryProvider = Provider<PrivacyPoliciesRepository>((ref) {
+  final dataSource = ref.watch(privacyPoliciesDataSourceProvider);
+  return PrivacyPoliciesRepositoryImpl(privacyPoliciesDataSource: dataSource);
 });

--- a/lib/core/exception/app_exception.dart
+++ b/lib/core/exception/app_exception.dart
@@ -84,6 +84,12 @@ sealed class AppException with _$AppException implements Exception {
     StackTrace? stackTrace,
   }) = TempStoreException;
 
+  const factory AppException.privacyPolicies({
+    required String message,
+    Object? error,
+    StackTrace? stackTrace,
+  }) = PrivacyPoliciesException;
+
   const factory AppException.unknownUser({
     required String message,
     Object? error,
@@ -119,6 +125,8 @@ sealed class AppException with _$AppException implements Exception {
         return '오류가 발생했습니다. 다시 시도해주세요.';
       case UnknownUserException():
         return '사용자를 불러올 수 없습니다.';
+      case PrivacyPoliciesException():
+        return '개인정보처리방침을 불러올 수 없습니다.';
     }
   }
 }

--- a/lib/core/routing/redirect.dart
+++ b/lib/core/routing/redirect.dart
@@ -13,7 +13,7 @@ abstract class AppRedirect {
   }) {
     // 0. 모든 사용자는 랜딩페이지, 요금제 안내 페이지에 접근 가능
     if (nowPath == Routes.landingPage ||
-        nowPath == Routes.paymentPlans) {
+        nowPath == Routes.paymentPlans || nowPath == Routes.privacyPolicies) {
       return null;
     }
 

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -25,13 +25,14 @@ import 'package:mongo_ai/dashboard/presentation/recent_files/recent_files_screen
 import 'package:mongo_ai/landing/presentation/landing_page/screen/landing_page_screen.dart';
 import 'package:mongo_ai/landing/presentation/landing_shell/screen/landing_shell_screen_root.dart';
 import 'package:mongo_ai/landing/presentation/payment_plans/screen/payment_plans_screen_root.dart';
+import 'package:mongo_ai/landing/presentation/privacy_policies/screen/privacy_policies_screen_root.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
   final auth = ref.watch(authRepositoryProvider);
   return GoRouter(
     //TODO(ok): 배포 전 랜딩페이지로 변경 예정
-    initialLocation: Routes.landingPage,
+    initialLocation: Routes.privacyPolicies,
     // auth 관찰해서 변화가 있다면,
     // 새로 reidrect 함수 실행
     refreshListenable: auth,
@@ -120,6 +121,14 @@ final routerProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: Routes.paymentPlans,
                 builder: (context, state) => const PaymentPlansScreenRoot(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: Routes.privacyPolicies,
+                builder: (context, state) => const PrivacyPoliciesScreenRoot(),
               ),
             ],
           ),

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -31,8 +31,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 final routerProvider = Provider<GoRouter>((ref) {
   final auth = ref.watch(authRepositoryProvider);
   return GoRouter(
-    //TODO(ok): 배포 전 랜딩페이지로 변경 예정
-    initialLocation: Routes.privacyPolicies,
+    initialLocation: Routes.landingPage,
     // auth 관찰해서 변화가 있다면,
     // 새로 reidrect 함수 실행
     refreshListenable: auth,

--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -20,4 +20,5 @@ abstract class Routes {
 
   static const landingPage = '/home';
   static const paymentPlans = '/payment-plans';
+  static const privacyPolicies = '/privacy-policies';
 }

--- a/lib/landing/data/data_source/privacy_policies_data_source.dart
+++ b/lib/landing/data/data_source/privacy_policies_data_source.dart
@@ -1,3 +1,5 @@
-abstract interface class PrivacyPoliciesDataSource {
+import 'package:mongo_ai/landing/data/dto/privacy_policies_dto.dart';
 
+abstract interface class PrivacyPoliciesDataSource {
+  Future<PrivacyPoliciesDto> fetchPrivacyPolicies(String language);
 }

--- a/lib/landing/data/data_source/privacy_policies_data_source.dart
+++ b/lib/landing/data/data_source/privacy_policies_data_source.dart
@@ -1,0 +1,3 @@
+abstract interface class PrivacyPoliciesDataSource {
+
+}

--- a/lib/landing/data/data_source/privacy_policies_data_source_impl.dart
+++ b/lib/landing/data/data_source/privacy_policies_data_source_impl.dart
@@ -1,0 +1,5 @@
+import './privacy_policies_data_source.dart';
+
+class PrivacyPoliciesDataSourceImpl implements PrivacyPoliciesDataSource {
+  
+}

--- a/lib/landing/data/data_source/privacy_policies_data_source_impl.dart
+++ b/lib/landing/data/data_source/privacy_policies_data_source_impl.dart
@@ -1,5 +1,23 @@
-import './privacy_policies_data_source.dart';
+import 'package:mongo_ai/core/constants/app_table_name.dart';
+import 'package:mongo_ai/landing/data/data_source/privacy_policies_data_source.dart';
+import 'package:mongo_ai/landing/data/dto/privacy_policies_dto.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class PrivacyPoliciesDataSourceImpl implements PrivacyPoliciesDataSource {
-  
+  final SupabaseClient _client;
+
+  const PrivacyPoliciesDataSourceImpl({required SupabaseClient client})
+    : _client = client;
+
+  @override
+  Future<PrivacyPoliciesDto> fetchPrivacyPolicies(String language) async {
+    final data =
+        await _client
+            .from(AppTableName.privacyPolicies)
+            .select()
+            .eq('language', language)
+            .single();
+
+    return PrivacyPoliciesDto.fromJson(data);
+  }
 }

--- a/lib/landing/data/dto/privacy_policies_dto.dart
+++ b/lib/landing/data/dto/privacy_policies_dto.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'privacy_policies_dto.g.dart';
+
+@JsonSerializable()
+class PrivacyPoliciesDto {
+  num? id;
+  String? content;
+  String? language;
+
+  PrivacyPoliciesDto({
+    this.id,
+    this.content,
+    this.language,
+  });
+
+  factory PrivacyPoliciesDto.fromJson(Map<String, dynamic> json) => _$PrivacyPoliciesDtoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PrivacyPoliciesDtoToJson(this);
+}

--- a/lib/landing/data/mapper/privacy_policies_mapper.dart
+++ b/lib/landing/data/mapper/privacy_policies_mapper.dart
@@ -1,0 +1,12 @@
+import 'package:mongo_ai/landing/data/dto/privacy_policies_dto.dart';
+import 'package:mongo_ai/landing/domain/model/privacy_policies.dart';
+
+extension PrivacyPoliciesMapper on PrivacyPoliciesDto {
+  PrivacyPolicies toPrivacyPolicies() {
+    return PrivacyPolicies(
+      id: id?.toInt() ?? -1,
+      content: content ?? '',
+      language: language ?? 'ko-KR',
+    );
+  }
+}

--- a/lib/landing/data/repository/privacy_policies_repository_impl.dart
+++ b/lib/landing/data/repository/privacy_policies_repository_impl.dart
@@ -1,4 +1,8 @@
+import 'package:mongo_ai/core/exception/app_exception.dart';
+import 'package:mongo_ai/core/result/result.dart';
 import 'package:mongo_ai/landing/data/data_source/privacy_policies_data_source.dart';
+import 'package:mongo_ai/landing/data/mapper/privacy_policies_mapper.dart';
+import 'package:mongo_ai/landing/domain/model/privacy_policies.dart';
 import 'package:mongo_ai/landing/domain/repository/privacy_policies_repository.dart';
 
 
@@ -8,4 +12,20 @@ class PrivacyPoliciesRepositoryImpl implements PrivacyPoliciesRepository {
   const PrivacyPoliciesRepositoryImpl({
     required PrivacyPoliciesDataSource privacyPoliciesDataSource,
   }) : _privacyPoliciesDataSource = privacyPoliciesDataSource;
+
+  @override
+  Future<Result<PrivacyPolicies, AppException>> getKoreanPrivacyPolicies() async {
+    try {
+      final dto = await _privacyPoliciesDataSource.fetchPrivacyPolicies('ko-KR');
+      return Result.success(dto.toPrivacyPolicies());
+    } catch (e) {
+      return Result.error(
+        AppException.privacyPolicies(
+          message: '개인정보처리방침을 가져오는 중 문제가 발생했습니다 error: $e',
+          stackTrace: StackTrace.current,
+        ),
+      );
+    }
+
+  }
 }

--- a/lib/landing/data/repository/privacy_policies_repository_impl.dart
+++ b/lib/landing/data/repository/privacy_policies_repository_impl.dart
@@ -1,0 +1,11 @@
+import 'package:mongo_ai/landing/data/data_source/privacy_policies_data_source.dart';
+import 'package:mongo_ai/landing/domain/repository/privacy_policies_repository.dart';
+
+
+class PrivacyPoliciesRepositoryImpl implements PrivacyPoliciesRepository {
+  final PrivacyPoliciesDataSource _privacyPoliciesDataSource;
+
+  const PrivacyPoliciesRepositoryImpl({
+    required PrivacyPoliciesDataSource privacyPoliciesDataSource,
+  }) : _privacyPoliciesDataSource = privacyPoliciesDataSource;
+}

--- a/lib/landing/domain/model/privacy_policies.dart
+++ b/lib/landing/domain/model/privacy_policies.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'privacy_policies.freezed.dart';
+
+@freezed
+abstract class PrivacyPolicies with _$PrivacyPolicies {
+  const factory PrivacyPolicies({
+    required int id,
+    required String content,
+    required String language,
+  }) = _PrivacyPolicies;
+}

--- a/lib/landing/domain/repository/privacy_policies_repository.dart
+++ b/lib/landing/domain/repository/privacy_policies_repository.dart
@@ -1,0 +1,3 @@
+abstract interface class PrivacyPoliciesRepository {
+
+}

--- a/lib/landing/domain/repository/privacy_policies_repository.dart
+++ b/lib/landing/domain/repository/privacy_policies_repository.dart
@@ -1,3 +1,7 @@
-abstract interface class PrivacyPoliciesRepository {
+import 'package:mongo_ai/core/exception/app_exception.dart';
+import 'package:mongo_ai/core/result/result.dart';
+import 'package:mongo_ai/landing/domain/model/privacy_policies.dart';
 
+abstract interface class PrivacyPoliciesRepository {
+  Future<Result<PrivacyPolicies, AppException>> getKoreanPrivacyPolicies();
 }

--- a/lib/landing/presentation/components/landing_footer.dart
+++ b/lib/landing/presentation/components/landing_footer.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:mongo_ai/core/style/app_color.dart';
 import 'package:mongo_ai/core/style/app_text_style.dart';
+import 'package:mongo_ai/landing/presentation/components/landing_footer_social_icon.dart';
 
 class LandingFooter extends StatelessWidget {
-  const LandingFooter({super.key});
+  final VoidCallback onPressedPrivacyPolicies;
+
+  const LandingFooter({super.key, required this.onPressedPrivacyPolicies});
 
   @override
   Widget build(BuildContext context) {
@@ -43,15 +46,15 @@ class LandingFooter extends StatelessWidget {
                             ),
                           ),
                           const SizedBox(height: 16),
-                          Wrap(
+                          const Wrap(
                             children: [
-                              _buildSocialIcon(Icons.facebook),
-                              const SizedBox(width: 16),
-                              _buildSocialIcon(Icons.web),
-                              const SizedBox(width: 16),
-                              _buildSocialIcon(Icons.email),
-                              const SizedBox(width: 16),
-                              _buildSocialIcon(Icons.chat),
+                              LandingFooterSocialIcon(icon: Icons.facebook),
+                              SizedBox(width: 16),
+                              LandingFooterSocialIcon(icon: Icons.web),
+                              SizedBox(width: 16),
+                              LandingFooterSocialIcon(icon: Icons.email),
+                              SizedBox(width: 16),
+                              LandingFooterSocialIcon(icon: Icons.chat),
                             ],
                           ),
                         ],
@@ -69,13 +72,13 @@ class LandingFooter extends StatelessWidget {
                             ),
                           ),
                           const SizedBox(height: 16),
-                          _buildFooterLink('기능'),
+                          const LandingFooterLinkButton(text: '기능'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('요금제'),
+                          const LandingFooterLinkButton(text: '요금제'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('로드맵'),
+                          const LandingFooterLinkButton(text: '로드맵'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('업데이트'),
+                          const LandingFooterLinkButton(text: '업데이트'),
                         ],
                       ),
                     ),
@@ -91,13 +94,13 @@ class LandingFooter extends StatelessWidget {
                             ),
                           ),
                           const SizedBox(height: 16),
-                          _buildFooterLink('도움말 센터'),
+                          const LandingFooterLinkButton(text: '도움말 센터'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('튜토리얼'),
+                          const LandingFooterLinkButton(text: '튜토리얼'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('FAQ'),
+                          const LandingFooterLinkButton(text: 'FAQ'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('문의하기'),
+                          const LandingFooterLinkButton(text: '문의하기'),
                         ],
                       ),
                     ),
@@ -113,13 +116,13 @@ class LandingFooter extends StatelessWidget {
                             ),
                           ),
                           const SizedBox(height: 16),
-                          _buildFooterLink('소개'),
+                          const LandingFooterLinkButton(text: '소개'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('블로그'),
+                          const LandingFooterLinkButton(text: '블로그'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('채용'),
+                          const LandingFooterLinkButton(text: '채용'),
                           const SizedBox(height: 8),
-                          _buildFooterLink('연락처'),
+                          const LandingFooterLinkButton(text: '연락처'),
                         ],
                       ),
                     ),
@@ -151,11 +154,15 @@ class LandingFooter extends StatelessWidget {
                       ),
                       Row(
                         children: [
-                          _buildFooterLink('이용약관', fontSize: 14),
+                          const LandingFooterLinkButton(text: '이용약관', fontSize: 14),
                           const SizedBox(width: 16),
-                          _buildFooterLink('개인정보처리방침', fontSize: 14),
+                          LandingFooterLinkButton(
+                            onPressed: onPressedPrivacyPolicies,
+                            text: '개인정보처리방침',
+                            fontSize: 14,
+                          ),
                           const SizedBox(width: 16),
-                          _buildFooterLink('쿠키 정책', fontSize: 14),
+                          const LandingFooterLinkButton(text: '쿠키 정책', fontSize: 14),
                         ],
                       ),
                     ],
@@ -168,25 +175,30 @@ class LandingFooter extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildSocialIcon(IconData icon) {
-    return Container(
-      width: 32,
-      height: 32,
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Icon(icon, color: AppColor.paleGray, size: 16),
-    );
-  }
+class LandingFooterLinkButton extends StatelessWidget {
+  final String text;
+  final double fontSize;
+  final VoidCallback? onPressed;
 
-  Widget _buildFooterLink(String text, {double fontSize = 16}) {
-    return Text(
-      text,
-      style: AppTextStyle.bodyRegular.copyWith(
-        color: AppColor.paleGray,
-        fontSize: fontSize,
+  const LandingFooterLinkButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    double? fontSize,
+  }) : fontSize = fontSize ?? 16;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: onPressed,
+      child: Text(
+        text,
+        style: AppTextStyle.bodyRegular.copyWith(
+          color: AppColor.paleGray,
+          fontSize: fontSize,
+        ),
       ),
     );
   }

--- a/lib/landing/presentation/components/landing_footer_social_icon.dart
+++ b/lib/landing/presentation/components/landing_footer_social_icon.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:mongo_ai/core/style/app_color.dart';
+
+class LandingFooterSocialIcon extends StatelessWidget {
+  final IconData icon;
+  const LandingFooterSocialIcon({
+    super.key, required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Icon(icon, color: AppColor.paleGray, size: 16),
+    );
+  }
+}

--- a/lib/landing/presentation/landing_page/controller/landing_page_action.dart
+++ b/lib/landing/presentation/landing_page/controller/landing_page_action.dart
@@ -5,4 +5,6 @@ part 'landing_page_action.freezed.dart';
 @freezed
 sealed class LandingPageAction with _$LandingPageAction {
   const factory LandingPageAction.goToSignIn() = GoToSignIn;
+
+  const factory LandingPageAction.onPressedPrivacyPolicies() = OnPressedPrivacyPolicies;
 }

--- a/lib/landing/presentation/landing_page/screen/landing_page_screen.dart
+++ b/lib/landing/presentation/landing_page/screen/landing_page_screen.dart
@@ -38,6 +38,8 @@ class LandingPageScreen extends StatelessWidget {
     switch (action) {
       case GoToSignIn():
         context.go(Routes.signIn);
+      case OnPressedPrivacyPolicies():
+        context.go(Routes.privacyPolicies);
     }
   }
 }

--- a/lib/landing/presentation/landing_page/screen/landing_page_view/landing_start_view.dart
+++ b/lib/landing/presentation/landing_page/screen/landing_page_view/landing_start_view.dart
@@ -64,7 +64,9 @@ class LandingStartView extends StatelessWidget {
             ),
           ),
         ),
-        const LandingFooter(),
+        LandingFooter(onPressedPrivacyPolicies: () {
+          onAction(const LandingPageAction.onPressedPrivacyPolicies());
+        },),
       ],
     );
   }

--- a/lib/landing/presentation/payment_plans/controller/payment_plans_action.dart
+++ b/lib/landing/presentation/payment_plans/controller/payment_plans_action.dart
@@ -9,4 +9,6 @@ sealed class PaymentPlansAction with _$PaymentPlansAction {
   const factory PaymentPlansAction.onUpgradeClick() = OnUpgradeClick;
 
   const factory PaymentPlansAction.onFreeTrialClick() = OnFreeTrialClick;
+
+  const factory PaymentPlansAction.onPressedPrivacyPolicies() = OnPressedPrivacyPolicies;
 }

--- a/lib/landing/presentation/payment_plans/screen/payment_plans_screen.dart
+++ b/lib/landing/presentation/payment_plans/screen/payment_plans_screen.dart
@@ -223,7 +223,9 @@ class _PaymentPlansScreenState extends State<PaymentPlansScreen> {
             ),
 
 
-            const LandingFooter(),
+            LandingFooter(onPressedPrivacyPolicies: () {
+              widget.onAction(const PaymentPlansAction.onPressedPrivacyPolicies());
+            },),
           ],
         ),
       ),

--- a/lib/landing/presentation/payment_plans/screen/payment_plans_screen_root.dart
+++ b/lib/landing/presentation/payment_plans/screen/payment_plans_screen_root.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mongo_ai/core/routing/routes.dart';
 import 'package:mongo_ai/landing/domain/enum/landing_header_menu_type.dart';
 import 'package:mongo_ai/landing/presentation/landing_shell/controller/landing_shell_view_model.dart';
 import 'package:mongo_ai/landing/presentation/payment_plans/controller/payment_plans_action.dart';
@@ -71,6 +73,8 @@ class _PaymentPlansScreenRootState
       case OnFreeTrialClick():
         viewModel.showFreeTrial();
         debugPrint('무료로 시작하기 버튼 클릭');
+      case OnPressedPrivacyPolicies():
+        context.go(Routes.privacyPolicies);
     }
   }
 }

--- a/lib/landing/presentation/privacy_policies/controller/privacy_policies_state.dart
+++ b/lib/landing/presentation/privacy_policies/controller/privacy_policies_state.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'privacy_policies_state.freezed.dart';
+
+@freezed
+abstract class PrivacyPoliciesState with _$PrivacyPoliciesState {
+  const factory PrivacyPoliciesState({
+    @Default(AsyncValue.data(null)) AsyncValue<dynamic> data,
+  }) = _PrivacyPoliciesState;
+}

--- a/lib/landing/presentation/privacy_policies/controller/privacy_policies_state.dart
+++ b/lib/landing/presentation/privacy_policies/controller/privacy_policies_state.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mongo_ai/landing/domain/model/privacy_policies.dart';
 
 part 'privacy_policies_state.freezed.dart';
 
 @freezed
 abstract class PrivacyPoliciesState with _$PrivacyPoliciesState {
   const factory PrivacyPoliciesState({
-    @Default(AsyncValue.data(null)) AsyncValue<dynamic> data,
+    @Default(AsyncValue.loading()) AsyncValue<PrivacyPolicies> data,
   }) = _PrivacyPoliciesState;
 }

--- a/lib/landing/presentation/privacy_policies/controller/privacy_policies_view_model.dart
+++ b/lib/landing/presentation/privacy_policies/controller/privacy_policies_view_model.dart
@@ -1,3 +1,7 @@
+import 'package:mongo_ai/core/di/providers.dart';
+import 'package:mongo_ai/core/exception/app_exception.dart';
+import 'package:mongo_ai/core/result/result.dart';
+import 'package:mongo_ai/landing/domain/model/privacy_policies.dart';
 import 'package:mongo_ai/landing/presentation/privacy_policies/controller/privacy_policies_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -8,5 +12,23 @@ class PrivacyPoliciesViewModel extends _$PrivacyPoliciesViewModel {
   @override
   PrivacyPoliciesState build() {
     return const PrivacyPoliciesState();
+  }
+
+  void fetchPrivacyPolicies() async {
+    state = state.copyWith(data: const AsyncLoading());
+    final repository = ref.read(privacyPoliciesRepositoryProvider);
+    final result = await repository.getKoreanPrivacyPolicies();
+
+    switch (result) {
+      case Success<PrivacyPolicies, AppException>():
+        state = state.copyWith(data: AsyncValue.data(result.data));
+      case Error<PrivacyPolicies, AppException>():
+        state = state.copyWith(
+          data: AsyncValue.error(
+            result.error,
+            result.error.stackTrace ?? StackTrace.empty,
+          ),
+        );
+    }
   }
 }

--- a/lib/landing/presentation/privacy_policies/controller/privacy_policies_view_model.dart
+++ b/lib/landing/presentation/privacy_policies/controller/privacy_policies_view_model.dart
@@ -1,0 +1,12 @@
+import 'package:mongo_ai/landing/presentation/privacy_policies/controller/privacy_policies_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'privacy_policies_view_model.g.dart';
+
+@riverpod
+class PrivacyPoliciesViewModel extends _$PrivacyPoliciesViewModel {
+  @override
+  PrivacyPoliciesState build() {
+    return const PrivacyPoliciesState();
+  }
+}

--- a/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen.dart
+++ b/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+import 'package:mongo_ai/core/style/app_color.dart';
+import 'package:mongo_ai/core/style/app_text_style.dart';
 import 'package:mongo_ai/landing/presentation/privacy_policies/controller/privacy_policies_state.dart';
 
 class PrivacyPoliciesScreen extends StatefulWidget {
@@ -13,6 +17,55 @@ class PrivacyPoliciesScreen extends StatefulWidget {
 class _PrivacyPoliciesScreenState extends State<PrivacyPoliciesScreen> {
   @override
   Widget build(BuildContext context) {
-    return Placeholder();
+    return Scaffold(
+      body: widget.state.data.when(
+        data: (privacyPolicies) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '개인정보처리방침',
+                  style: AppTextStyle.titleBold.copyWith(
+                    fontSize: 24,
+                    color: AppColor.deepBlack,
+                  ),
+                ),
+                const Gap(32),
+                Text(
+                  privacyPolicies.content,
+                  style: AppTextStyle.bodyRegular.copyWith(
+                    color: AppColor.mediumGray,
+                    height: 1.6,
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(color: AppColor.primary),
+        ),
+        error: (error, stack) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.error_outline,
+                color: AppColor.destructive,
+                size: 48,
+              ),
+              const Gap(16),
+              Text(
+                '개인정보처리방침을 불러오는 중 오류가 발생했습니다.',
+                style: AppTextStyle.bodyMedium.copyWith(color: AppColor.mediumGray),
+              ),
+              const Gap(8),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen.dart
+++ b/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:mongo_ai/landing/presentation/privacy_policies/controller/privacy_policies_state.dart';
+
+class PrivacyPoliciesScreen extends StatefulWidget {
+  final PrivacyPoliciesState state;
+
+  const PrivacyPoliciesScreen({super.key, required this.state});
+
+  @override
+  State<PrivacyPoliciesScreen> createState() => _PrivacyPoliciesScreenState();
+}
+
+class _PrivacyPoliciesScreenState extends State<PrivacyPoliciesScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Placeholder();
+  }
+}

--- a/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen_root.dart
+++ b/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen_root.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongo_ai/landing/presentation/privacy_policies/controller/privacy_policies_view_model.dart';
+import 'package:mongo_ai/landing/presentation/privacy_policies/screen/privacy_policies_screen.dart';
+
+class PrivacyPoliciesScreenRoot extends ConsumerStatefulWidget {
+  const PrivacyPoliciesScreenRoot({super.key});
+
+  @override
+  ConsumerState<PrivacyPoliciesScreenRoot> createState() => _PrivacyPoliciesScreenRootState();
+}
+
+class _PrivacyPoliciesScreenRootState extends ConsumerState<PrivacyPoliciesScreenRoot> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final viewModel = ref.watch(privacyPoliciesViewModelProvider.notifier);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(privacyPoliciesViewModelProvider);
+
+    return Scaffold(
+      body: PrivacyPoliciesScreen(state: state),
+    );
+  }
+}

--- a/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen_root.dart
+++ b/lib/landing/presentation/privacy_policies/screen/privacy_policies_screen_root.dart
@@ -16,6 +16,8 @@ class _PrivacyPoliciesScreenRootState extends ConsumerState<PrivacyPoliciesScree
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final viewModel = ref.watch(privacyPoliciesViewModelProvider.notifier);
+
+      viewModel.fetchPrivacyPolicies();
     });
   }
 


### PR DESCRIPTION
## 🔍 변경사항 요약
- README 파일을 전면 개편하여 프로젝트 소개, 기술 스택, 팀원 정보 등을 상세히 업데이트
  - ⭐️ 추가, 수정이 자유롭습니다. 내용을 더욱 풍부하게 해주세요 
- 개인정보처리방침 기능 추가 (새로운 화면, 리포지토리, 데이터 소스 등)
  - supabase - table이 추가되었습니다. `privacy_policies`
- 회원가입 화면에서 개인정보처리방침 버튼 클릭 시 해당 페이지로 이동하는 기능 구현
- `AppTableName`에 개인정보처리방침 테이블명 추가
- 라우팅 설정 및 리다이렉트 로직 업데이트
- 랜딩 페이지 푸터 컴포넌트 리팩토링

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/a72f6908-a901-4dff-8dc4-049fc863ec06" />


## 📌 리뷰사항
- README.md에 잘못된 정보가 있는지 확인해주세요

## ✅ 체크리스트
- [x] 코드가 빌드 및 실행에 문제 없는가
- [x] 파일, 변수, 주석 등이 컨벤션 규칙에 맞게 준수되었는가
- [x] 변경된 코드가 기존 기능에 영향을 주지 않도록 설계되었는가
- [x] 변경된 파일에 대한 문서나 주석이 업데이트 되었는가
- [x] 리뷰어가 이해하기 쉽도록 변경사항 설명 작성


closed: #123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 개인정보처리방침(Privacy Policies) 페이지가 추가되어 누구나 접근할 수 있습니다.
  - 회원가입, 랜딩 페이지, 요금제 화면 및 푸터에서 개인정보처리방침 링크를 클릭하면 해당 페이지로 이동합니다.
  - 개인정보처리방침은 데이터베이스에서 불러오며, 로딩/에러/성공 상태에 따라 UI가 동적으로 표시됩니다.

- **UI 개선**
  - 랜딩 페이지 및 푸터의 소셜 아이콘, 링크 버튼이 재사용 가능한 컴포넌트로 개선되었습니다.
  - 개인정보처리방침 동의 문구가 버튼으로 대체되어, 클릭 시 정책 페이지로 이동합니다.

- **문서화**
  - README가 MongoAI 프로젝트 중심으로 전면 개편되어, 소개, 기능, 기술 스택, 아키텍처, 팀, 개발 문화, 마일스톤 등 상세 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->