### PR TITLE
fix, feat/로그인 유저 팀 선택 로직 수정, 팀 추가 선택 기능 추가

### DIFF
--- a/lib/auth/data/data_source/auth_data_source.dart
+++ b/lib/auth/data/data_source/auth_data_source.dart
@@ -39,7 +39,7 @@ abstract interface class AuthDataSource {
 
   bool isInitialSetupUser();
 
-  bool isSelectTeam();
+  bool isPreferredTeamSelected();
 
   String? userId();
 

--- a/lib/auth/data/data_source/auth_data_source.dart
+++ b/lib/auth/data/data_source/auth_data_source.dart
@@ -29,7 +29,7 @@ abstract interface class AuthDataSource {
 
   Future<String?> getCurrentUserEmail();
 
-  Future<void> updateUserMetadata(String key);
+  Future<void> updateUserMetadata(String key, bool isSelect);
 
   Future<void> saveSelectedTeamId(int teamId);
 

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -150,8 +150,8 @@ class AuthDataSourceImpl implements AuthDataSource {
   }
 
   @override
-  bool isSelectTeam() {
-    return checkMetadata('is_select_team');
+  bool isPreferredTeamSelected() {
+    return checkMetadata('is_preferred_team_selected');
   }
 
   @override

--- a/lib/auth/data/data_source/auth_data_source_impl.dart
+++ b/lib/auth/data/data_source/auth_data_source_impl.dart
@@ -119,8 +119,8 @@ class AuthDataSourceImpl implements AuthDataSource {
   }
 
   @override
-  Future<void> updateUserMetadata(String key) async {
-    await _client.auth.updateUser(UserAttributes(data: {key: true}));
+  Future<void> updateUserMetadata(String key, bool isSelect) async {
+    await _client.auth.updateUser(UserAttributes(data: {key: isSelect}));
   }
 
   @override

--- a/lib/auth/data/repository/auth_repository_impl.dart
+++ b/lib/auth/data/repository/auth_repository_impl.dart
@@ -51,7 +51,7 @@ class AuthRepositoryImpl extends AuthRepository {
     switch (result) {
       case Success():
       // 첫 로그인 여부 확인(팀 선택 미완료인지 아닌지)
-        final hasTeamNotSelected = !isSelectTeam;
+        final hasTeamNotSelected = !isPreferredTeamSelected;
         _notifyListeners(
           AuthStateChange.signedInWithGoogle(hasTeamNotSelected: hasTeamNotSelected),
         );
@@ -381,12 +381,12 @@ class AuthRepositoryImpl extends AuthRepository {
   @override
   Future<Result<void, AppException>> setSelectTeamMetadata() async {
     try {
-      await _authDataSource.updateUserMetadata('is_select_team');
+      await _authDataSource.updateUserMetadata('is_preferred_team_selected');
       return const Result.success(null);
     } catch (e) {
       return Result.error(
         AppException.unknown(
-          message: 'Metadata를 설정하던 중 오류가 발생했습니다: is_select_team',
+          message: 'Metadata를 설정하던 중 오류가 발생했습니다: is_preferred_team_selected',
           error: e,
           stackTrace: StackTrace.current,
         ),
@@ -405,8 +405,8 @@ class AuthRepositoryImpl extends AuthRepository {
   }
 
   @override
-  bool get isSelectTeam {
-    return _authDataSource.isSelectTeam();
+  bool get isPreferredTeamSelected {
+    return _authDataSource.isPreferredTeamSelected();
   }
 
   @override

--- a/lib/auth/data/repository/auth_repository_impl.dart
+++ b/lib/auth/data/repository/auth_repository_impl.dart
@@ -257,7 +257,7 @@ class AuthRepositoryImpl extends AuthRepository {
       await _authDataSource.saveUser();
 
       // 메타데이터 업데이트
-      await _authDataSource.updateUserMetadata('is_initial_setup_user');
+      await _authDataSource.updateUserMetadata('is_initial_setup_user', true);
       notifyListeners();
       return const Result.success(null);
     } catch (e) {
@@ -379,9 +379,9 @@ class AuthRepositoryImpl extends AuthRepository {
   }
 
   @override
-  Future<Result<void, AppException>> setSelectTeamMetadata() async {
+  Future<Result<void, AppException>> setIsPreferredTeamSelected(bool isSelect) async {
     try {
-      await _authDataSource.updateUserMetadata('is_preferred_team_selected');
+      await _authDataSource.updateUserMetadata('is_preferred_team_selected', isSelect);
       return const Result.success(null);
     } catch (e) {
       return Result.error(

--- a/lib/auth/domain/repository/auth_repository.dart
+++ b/lib/auth/domain/repository/auth_repository.dart
@@ -111,7 +111,7 @@ abstract class AuthRepository extends ChangeNotifier {
   Future<Result<String, AppException>> getCurrentUserEmail();
 
   /// 팀 선택 완료 메타데이터를 설정합니다.
-  Future<Result<void, AppException>> setSelectTeamMetadata();
+  Future<Result<void, AppException>> setIsPreferredTeamSelected(bool isSelect);
 
   /// 현재 사용자의 인증 제공자(구글, 이메일/비밀번호 등)를 반환합니다.
   ///

--- a/lib/auth/domain/repository/auth_repository.dart
+++ b/lib/auth/domain/repository/auth_repository.dart
@@ -15,9 +15,9 @@ abstract class AuthRepository extends ChangeNotifier {
   /// true: 초기 설정 완료, false: 초기 설정 미완료
   bool get isInitialSetupUser;
 
-  /// 사용자가 팀 선택을 완료했는지 여부를 반환합니다.
+  /// 사용자가 팀 선택을 완료했는지 여부를 반환합니다. 팀을 추가 선택시에도 사용됩니다.
   /// true: 팀 선택 완료, false: 팀 선택 미완료
-  bool get isSelectTeam;
+  bool get isPreferredTeamSelected;
 
   /// 현재 로그인된 사용자의 ID를 반환합니다.
   /// 로그인 되어 있지 않은 경우 null을 반환합니다.

--- a/lib/auth/presentation/components/select_team_main_content_panel.dart
+++ b/lib/auth/presentation/components/select_team_main_content_panel.dart
@@ -75,6 +75,22 @@ class MainContentPanel extends StatelessWidget {
                 ),
                 child: state.teams.when(
                   data: (teams) {
+                    if (teams.isEmpty) {
+                      return Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        child: const Text(
+                          '선택 가능한 팀이 없습니다. 팀을 새로 만들어보세요',
+                          style: TextStyle(
+                            fontFamily: AppTextStyle.fontFamily,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w400,
+                            color: AppColor.lightGray,
+                          ),
+                        ),
+                      );
+                    }
+
                     return DropdownButtonHideUnderline(
                       child: DropdownButton<Team>(
                         value: state.isCreatingNewTeam ? null : state.selectedTeam,

--- a/lib/auth/presentation/components/select_team_main_content_panel.dart
+++ b/lib/auth/presentation/components/select_team_main_content_panel.dart
@@ -284,6 +284,32 @@ class MainContentPanel extends StatelessWidget {
                 ),
               ),
 
+              const Gap(16),
+
+              Container(
+                width: double.infinity,
+                height: 48,
+                decoration: BoxDecoration(
+                  border: Border.all(color: AppColor.lighterGray),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: ElevatedButton(
+                  onPressed: () => onAction(const SelectTeamAction.onCancel()),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColor.white,
+                    foregroundColor: AppColor.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    elevation: 0,
+                  ),
+                  child: Text(
+                    '취소',
+                    style: AppTextStyle.bodyRegular.copyWith(color: AppColor.deepBlack)
+                  ),
+                ),
+              ),
+
               if (showInfoInSmallScreen) ...[
                 const Gap(32),
                 const Divider(height: 1, color: AppColor.lightGrayBorder),

--- a/lib/auth/presentation/components/select_team_main_content_panel.dart
+++ b/lib/auth/presentation/components/select_team_main_content_panel.dart
@@ -284,31 +284,36 @@ class MainContentPanel extends StatelessWidget {
                 ),
               ),
 
-              const Gap(16),
+              if (state.isUserInAnyTeam)
+                Column(
+                  children: [
+                    const Gap(16),
 
-              Container(
-                width: double.infinity,
-                height: 48,
-                decoration: BoxDecoration(
-                  border: Border.all(color: AppColor.lighterGray),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: ElevatedButton(
-                  onPressed: () => onAction(const SelectTeamAction.onCancel()),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColor.white,
-                    foregroundColor: AppColor.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
+                    Container(
+                      width: double.infinity,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        border: Border.all(color: AppColor.lighterGray),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: ElevatedButton(
+                        onPressed: () => onAction(const SelectTeamAction.onCancel()),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColor.white,
+                          foregroundColor: AppColor.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          elevation: 0,
+                        ),
+                        child: Text(
+                          '취소',
+                          style: AppTextStyle.bodyRegular.copyWith(color: AppColor.deepBlack)
+                        ),
+                      ),
                     ),
-                    elevation: 0,
-                  ),
-                  child: Text(
-                    '취소',
-                    style: AppTextStyle.bodyRegular.copyWith(color: AppColor.deepBlack)
-                  ),
+                  ],
                 ),
-              ),
 
               if (showInfoInSmallScreen) ...[
                 const Gap(32),

--- a/lib/auth/presentation/select_team/controller/select_team_action.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_action.dart
@@ -13,4 +13,6 @@ sealed class SelectTeamAction with _$SelectTeamAction {
 
   const factory SelectTeamAction.onToggleCreateNewTeam() =
       OnToggleCreateNewTeam;
+
+  const factory SelectTeamAction.onCancel() = OnCancel;
 }

--- a/lib/auth/presentation/select_team/controller/select_team_event.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_event.dart
@@ -6,5 +6,5 @@ part 'select_team_event.freezed.dart';
 sealed class SelectTeamEvent with _$SelectTeamEvent {
   const factory SelectTeamEvent.showSnackBar(String message) = ShowSnackBar;
 
-  const factory SelectTeamEvent.confirmSuccess() = ConfirmSuccess;
+  const factory SelectTeamEvent.navigateToMyFile() = NavigateToMyFile;
 }

--- a/lib/auth/presentation/select_team/controller/select_team_state.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_state.dart
@@ -12,6 +12,7 @@ abstract class SelectTeamState with _$SelectTeamState {
     @Default(null) Team? selectedTeam,
     @Default(false) bool isCreatingNewTeam,
     @Default(null) String? userId,
+    @Default(false) bool isUserInAnyTeam,
     required TextEditingController teamNameController,
   }) = _SelectTeamState;
 }

--- a/lib/auth/presentation/select_team/controller/select_team_view_model.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_view_model.dart
@@ -166,4 +166,18 @@ class SelectTeamViewModel extends _$SelectTeamViewModel {
     await ref.read(authRepositoryProvider).setIsPreferredTeamSelected(true);
     onComplete();
   }
+
+  Future<void> checkIsUserInAnyTeam() async {
+    final result = await ref.read(teamRepositoryProvider).isUserInAnyTeam();
+
+    switch (result) {
+      case Success():
+        final isUserInAnyTeam = result.data;
+        state = state.copyWith(isUserInAnyTeam: isUserInAnyTeam);
+      case Error(error: final error):
+        _eventController.add(
+          SelectTeamEvent.showSnackBar(error.userFriendlyMessage),
+        );
+    }
+  }
 }

--- a/lib/auth/presentation/select_team/controller/select_team_view_model.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_view_model.dart
@@ -145,7 +145,7 @@ class SelectTeamViewModel extends _$SelectTeamViewModel {
 
         await authRepository.saveSelectedTeamId(selectedTeam.teamId);
 
-        final metadataResult = await authRepository.setSelectTeamMetadata();
+        final metadataResult = await authRepository.setIsPreferredTeamSelected(true);
 
         switch (metadataResult) {
           case Success():

--- a/lib/auth/presentation/select_team/controller/select_team_view_model.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_view_model.dart
@@ -161,4 +161,9 @@ class SelectTeamViewModel extends _$SelectTeamViewModel {
         );
     }
   }
+
+  Future<void> cancelTeamSelect(VoidCallback onComplete) async {
+    await ref.read(authRepositoryProvider).setIsPreferredTeamSelected(true);
+    onComplete();
+  }
 }

--- a/lib/auth/presentation/select_team/controller/select_team_view_model.dart
+++ b/lib/auth/presentation/select_team/controller/select_team_view_model.dart
@@ -149,7 +149,7 @@ class SelectTeamViewModel extends _$SelectTeamViewModel {
 
         switch (metadataResult) {
           case Success():
-            _eventController.add(const SelectTeamEvent.confirmSuccess());
+            _eventController.add(const SelectTeamEvent.navigateToMyFile());
           case Error(error: final error):
             _eventController.add(
               SelectTeamEvent.showSnackBar(error.userFriendlyMessage),
@@ -162,9 +162,9 @@ class SelectTeamViewModel extends _$SelectTeamViewModel {
     }
   }
 
-  Future<void> cancelTeamSelect(VoidCallback onComplete) async {
+  Future<void> cancelTeamSelect() async {
     await ref.read(authRepositoryProvider).setIsPreferredTeamSelected(true);
-    onComplete();
+    _eventController.add(const SelectTeamEvent.navigateToMyFile());
   }
 
   Future<void> checkIsUserInAnyTeam() async {

--- a/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
+++ b/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
@@ -91,6 +91,7 @@ class _SelectGroupScreenRootState extends ConsumerState<SelectTeamScreenRoot> {
         break;
       case OnCancel():
         viewModel.cancelTeamSelect();
+        break;
     }
   }
 }

--- a/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
+++ b/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
@@ -86,6 +86,10 @@ class _SelectGroupScreenRootState extends ConsumerState<SelectTeamScreenRoot> {
       case OnToggleCreateNewTeam():
         viewModel.toggleCreateNewTeam();
         break;
+      case OnCancel():
+        viewModel.cancelTeamSelect(() {
+          context.go(Routes.myFiles);
+        });
     }
   }
 }

--- a/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
+++ b/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
@@ -33,6 +33,9 @@ class _SelectGroupScreenRootState extends ConsumerState<SelectTeamScreenRoot> {
       // 유저 아이디 불러오기
       viewModel.fetchUserId();
 
+      // 유저가 어느 한 팀 이상에 속해있는지
+      viewModel.checkIsUserInAnyTeam();
+
       // 이벤트 리스너 등록
       _subscription = viewModel.eventStream.listen(_handleEvent);
     });

--- a/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
+++ b/lib/auth/presentation/select_team/screen/select_team_screen_root.dart
@@ -56,7 +56,7 @@ class _SelectGroupScreenRootState extends ConsumerState<SelectTeamScreenRoot> {
           ).showSnackBar(SnackBar(content: Text(message)));
         }
         break;
-      case ConfirmSuccess():
+      case NavigateToMyFile():
         if (mounted) {
           context.go(Routes.myFiles);
         }
@@ -90,9 +90,7 @@ class _SelectGroupScreenRootState extends ConsumerState<SelectTeamScreenRoot> {
         viewModel.toggleCreateNewTeam();
         break;
       case OnCancel():
-        viewModel.cancelTeamSelect(() {
-          context.go(Routes.myFiles);
-        });
+        viewModel.cancelTeamSelect();
     }
   }
 }

--- a/lib/core/routing/redirect.dart
+++ b/lib/core/routing/redirect.dart
@@ -7,7 +7,7 @@ abstract class AppRedirect {
   static String? authRedirect({
     required bool isAuthenticated,
     required bool isInitialSetupUser,
-    required bool isSelectTeam,
+    required bool isPreferredTeamSelected,
     required String? nowPath,
     required Object? extra,
   }) {
@@ -50,8 +50,8 @@ abstract class AppRedirect {
       return null;
     }
 
-    // 3. 인증은 됐고 초기설정은 됐지만 팀 설정이 안됐을 경우
-    if (!isSelectTeam) {
+    // 3. 인증은 됐고 초기설정은 됐지만 팀 설정이 안됐을 경우 또는 팀을 추가 선택할 경우
+    if (!isPreferredTeamSelected) {
       return Routes.selectTeam;
     }
 

--- a/lib/core/routing/router.dart
+++ b/lib/core/routing/router.dart
@@ -41,7 +41,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       return AppRedirect.authRedirect(
         isAuthenticated: auth.isAuthenticated,
         isInitialSetupUser: auth.isInitialSetupUser,
-        isSelectTeam: auth.isSelectTeam,
+        isPreferredTeamSelected: auth.isPreferredTeamSelected,
         nowPath: path,
         extra: extra,
       );

--- a/lib/dashboard/data/data_source/team_data_source.dart
+++ b/lib/dashboard/data/data_source/team_data_source.dart
@@ -9,4 +9,6 @@ abstract interface class TeamDataSource {
   Future<TeamDto> createTeam(String teamName, String? teamImage);
 
   Future<void> assignUserToTeam(String userId, int teamId);
+
+  Future<bool> isUserInAnyTeam();
 }

--- a/lib/dashboard/data/data_source/team_data_source_impl.dart
+++ b/lib/dashboard/data/data_source/team_data_source_impl.dart
@@ -21,11 +21,13 @@ class TeamDataSourceImpl implements TeamDataSource {
 
   @override
   Future<List<TeamDto>> getAllTeams() async {
-    final data = await _client
-        .from('team')
-        .select('team_id, team_name, team_image, created_at');
+    final result = await _client
+        .rpc('get_non_joined_teams', params: {
+      'user_uuid': _client.auth.currentUser!.id
+    });
 
-    return data.map((e) => TeamDto.fromJson(e)).toList();
+    final List<dynamic> data = result;
+    return data.map((e) => TeamDto.fromJson(e as Map<String, dynamic>)).toList();
   }
 
   @override

--- a/lib/dashboard/data/data_source/team_data_source_impl.dart
+++ b/lib/dashboard/data/data_source/team_data_source_impl.dart
@@ -21,9 +21,10 @@ class TeamDataSourceImpl implements TeamDataSource {
 
   @override
   Future<List<TeamDto>> getAllTeams() async {
+    final userId = _client.auth.currentUser!.id;
     final result = await _client
         .rpc('get_non_joined_teams', params: {
-      'user_uuid': _client.auth.currentUser!.id
+      'user_uuid': userId
     });
 
     final List<dynamic> data = result;
@@ -52,5 +53,16 @@ class TeamDataSourceImpl implements TeamDataSource {
       'user_id': userId,
       'team_id': teamId,
     });
+  }
+
+  @override
+  Future<bool> isUserInAnyTeam() async {
+    final userId = _client.auth.currentUser!.id;
+    final data = await _client
+        .from('team_users')
+        .select('team_id')
+        .eq('user_id', userId);
+
+    return data.isNotEmpty;
   }
 }

--- a/lib/dashboard/data/repository/team_repository_impl.dart
+++ b/lib/dashboard/data/repository/team_repository_impl.dart
@@ -36,7 +36,6 @@ class TeamRepositoryImpl implements TeamRepository {
       final teams = teamDtos.map((e) => e.toTeam()).toList();
       return Result.success(teams);
     } catch (e) {
-      print(e);
       return Result.error(
         AppException.remoteDataBase(
           message: '팀 목록을 가져오는 중 오류가 발생했습니다.',

--- a/lib/dashboard/data/repository/team_repository_impl.dart
+++ b/lib/dashboard/data/repository/team_repository_impl.dart
@@ -84,4 +84,20 @@ class TeamRepositoryImpl implements TeamRepository {
       );
     }
   }
+
+  @override
+  Future<Result<bool, AppException>> isUserInAnyTeam() async {
+    try {
+      final isUserNotInAnyTeam = await _dataSource.isUserInAnyTeam();
+      return Result.success(isUserNotInAnyTeam);
+    } catch (e) {
+      return Result.error(
+        AppException.remoteDataBase(
+          message: '사용자가 속한 팀이 있는지 확인하는 중 오류가 발생했습니다.',
+          error: e,
+          stackTrace: StackTrace.current,
+        ),
+      );
+    }
+  }
 }

--- a/lib/dashboard/domain/repository/team_repository.dart
+++ b/lib/dashboard/domain/repository/team_repository.dart
@@ -8,6 +8,8 @@ abstract interface class TeamRepository {
   // 현재 사용자가 속한 팀을 제외하고 모든 팀 목록 가져오기
   Future<Result<List<Team>, AppException>> getAllTeams();
 
+  Future<Result<bool, AppException>> isUserInAnyTeam();
+
   Future<Result<Team, AppException>> createTeam(
     String teamName,
     String? teamImage,

--- a/lib/dashboard/domain/repository/team_repository.dart
+++ b/lib/dashboard/domain/repository/team_repository.dart
@@ -5,6 +5,7 @@ import 'package:mongo_ai/dashboard/domain/model/team.dart';
 abstract interface class TeamRepository {
   Future<Result<List<Team>, AppException>> getTeamsByCurrentUser();
 
+  // 현재 사용자가 속한 팀을 제외하고 모든 팀 목록 가져오기
   Future<Result<List<Team>, AppException>> getAllTeams();
 
   Future<Result<Team, AppException>> createTeam(

--- a/lib/dashboard/presentation/controller/dashboard_view_model.dart
+++ b/lib/dashboard/presentation/controller/dashboard_view_model.dart
@@ -195,6 +195,11 @@ class DashboardViewModel extends _$DashboardViewModel {
     ref.read(currentTeamIdStateProvider.notifier).set(teamId);
   }
 
+  Future<void> selectNewTeam(VoidCallback onComplete) async {
+    await ref.read(authRepositoryProvider).setIsPreferredTeamSelected(false);
+    onComplete();
+  }
+
   // -----------------
   // 휴지통 관련 메서드
   Future<void> toggleDeleteMode() async {

--- a/lib/dashboard/presentation/dashboard_screen.dart
+++ b/lib/dashboard/presentation/dashboard_screen.dart
@@ -341,7 +341,9 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                   viewModel.selectTeam(teamId);
                 },
                 onCreateTeam: () {
-                  context.go(Routes.selectTeam);
+                  viewModel.selectNewTeam(() {
+                    context.go(Routes.selectTeam);
+                  });
                 },
               ),
             ),

--- a/test/auth/domain/repository/auth_repository_test.dart
+++ b/test/auth/domain/repository/auth_repository_test.dart
@@ -145,7 +145,7 @@ void main() {
       ).thenReturn(false);
       when(mockAuthDataSource.saveUser()).thenAnswer((_) async {});
       when(
-        mockAuthDataSource.updateUserMetadata('is_initial_setup_user'),
+        mockAuthDataSource.updateUserMetadata('is_initial_setup_user', true),
       ).thenAnswer((_) async {});
 
       final result = await authRepository.handleGoogleSignIn(user);
@@ -315,7 +315,7 @@ void main() {
     test('사용자 저장이 성공했을 때 Success를 반환해야 한다', () async {
       when(mockAuthDataSource.saveUser()).thenAnswer((_) async {});
       when(
-        mockAuthDataSource.updateUserMetadata('is_initial_setup_user'),
+        mockAuthDataSource.updateUserMetadata('is_initial_setup_user', true),
       ).thenAnswer((_) async {});
 
       final result = await authRepository.saveUser();
@@ -329,7 +329,7 @@ void main() {
 
       verify(mockAuthDataSource.saveUser()).called(1);
       verify(
-        mockAuthDataSource.updateUserMetadata('is_initial_setup_user'),
+        mockAuthDataSource.updateUserMetadata('is_initial_setup_user', true),
       ).called(1);
     });
 
@@ -439,7 +439,7 @@ void main() {
   group('setSelectTeamMetadata', () {
     test('팀 선택 메타데이터 설정이 성공했을 때 Success를 반환해야 한다', () async {
       when(
-        mockAuthDataSource.updateUserMetadata('is_preferred_team_selected'),
+        mockAuthDataSource.updateUserMetadata('is_preferred_team_selected', true),
       ).thenAnswer((_) async {});
 
       final result = await authRepository.setIsPreferredTeamSelected(true);
@@ -452,12 +452,12 @@ void main() {
           fail('메타데이터 설정이 성공해야 하지만 Error가 반환되었습니다.');
       }
 
-      verify(mockAuthDataSource.updateUserMetadata('is_preferred_team_selected')).called(1);
+      verify(mockAuthDataSource.updateUserMetadata('is_preferred_team_selected', true)).called(1);
     });
 
     test('메타데이터 설정이 실패했을 때 Error를 반환해야 한다', () async {
       when(
-        mockAuthDataSource.updateUserMetadata('is_preferred_team_selected'),
+        mockAuthDataSource.updateUserMetadata('is_preferred_team_selected', true),
       ).thenThrow(Exception('Metadata update failed'));
 
       final result = await authRepository.setIsPreferredTeamSelected(true);
@@ -472,7 +472,7 @@ void main() {
           );
       }
 
-      verify(mockAuthDataSource.updateUserMetadata('is_preferred_team_selected')).called(1);
+      verify(mockAuthDataSource.updateUserMetadata('is_preferred_team_selected', true)).called(1);
     });
   });
 }

--- a/test/auth/domain/repository/auth_repository_test.dart
+++ b/test/auth/domain/repository/auth_repository_test.dart
@@ -436,7 +436,7 @@ void main() {
     });
   });
 
-  group('setSelectTeamMetadata', () {
+  group('setIsPreferredTeamSelected', () {
     test('팀 선택 메타데이터 설정이 성공했을 때 Success를 반환해야 한다', () async {
       when(
         mockAuthDataSource.updateUserMetadata('is_preferred_team_selected', true),

--- a/test/auth/domain/repository/auth_repository_test.dart
+++ b/test/auth/domain/repository/auth_repository_test.dart
@@ -442,7 +442,7 @@ void main() {
         mockAuthDataSource.updateUserMetadata('is_preferred_team_selected'),
       ).thenAnswer((_) async {});
 
-      final result = await authRepository.setSelectTeamMetadata();
+      final result = await authRepository.setIsPreferredTeamSelected(true);
 
       // 검증: 결과가 Success인지 확인
       switch (result) {
@@ -460,7 +460,7 @@ void main() {
         mockAuthDataSource.updateUserMetadata('is_preferred_team_selected'),
       ).thenThrow(Exception('Metadata update failed'));
 
-      final result = await authRepository.setSelectTeamMetadata();
+      final result = await authRepository.setIsPreferredTeamSelected(true);
 
       switch (result) {
         case Success():

--- a/test/auth/domain/repository/auth_repository_test.dart
+++ b/test/auth/domain/repository/auth_repository_test.dart
@@ -51,7 +51,7 @@ void main() {
     // isAuthenticated, isInitialSetupUser, isSelectTeam 스텁 설정
     when(mockAuthDataSource.isAuthenticated()).thenReturn(true);
     when(mockAuthDataSource.isInitialSetupUser()).thenReturn(true);
-    when(mockAuthDataSource.isSelectTeam()).thenReturn(true);
+    when(mockAuthDataSource.isPreferredTeamSelected()).thenReturn(true);
 
     authRepository = AuthRepositoryImpl(authDataSource: mockAuthDataSource);
   });
@@ -439,7 +439,7 @@ void main() {
   group('setSelectTeamMetadata', () {
     test('팀 선택 메타데이터 설정이 성공했을 때 Success를 반환해야 한다', () async {
       when(
-        mockAuthDataSource.updateUserMetadata('is_select_team'),
+        mockAuthDataSource.updateUserMetadata('is_preferred_team_selected'),
       ).thenAnswer((_) async {});
 
       final result = await authRepository.setSelectTeamMetadata();
@@ -452,12 +452,12 @@ void main() {
           fail('메타데이터 설정이 성공해야 하지만 Error가 반환되었습니다.');
       }
 
-      verify(mockAuthDataSource.updateUserMetadata('is_select_team')).called(1);
+      verify(mockAuthDataSource.updateUserMetadata('is_preferred_team_selected')).called(1);
     });
 
     test('메타데이터 설정이 실패했을 때 Error를 반환해야 한다', () async {
       when(
-        mockAuthDataSource.updateUserMetadata('is_select_team'),
+        mockAuthDataSource.updateUserMetadata('is_preferred_team_selected'),
       ).thenThrow(Exception('Metadata update failed'));
 
       final result = await authRepository.setSelectTeamMetadata();
@@ -468,11 +468,11 @@ void main() {
         case Error():
           expect(
             result.error.message,
-            'Metadata를 설정하던 중 오류가 발생했습니다: is_select_team',
+            'Metadata를 설정하던 중 오류가 발생했습니다: is_preferred_team_selected',
           );
       }
 
-      verify(mockAuthDataSource.updateUserMetadata('is_select_team')).called(1);
+      verify(mockAuthDataSource.updateUserMetadata('is_preferred_team_selected')).called(1);
     });
   });
 }


### PR DESCRIPTION
## 🔍 변경사항 요약
- 팀 선택 관련 메타데이터 키를 `is_select_team`에서 `is_preferred_team_selected`로 변경하여 의미를 명확하게 했습니다.
- 메타데이터 업데이트 시 true/false값 설정을 위한 매개변수 추가 (`updateUserMetadata` 메서드에 `isSelect` 매개변수 추가)
- 팀 선택 화면에서 사용자가 이미 팀에 속해 있는 경우 취소 버튼 추가
- 팀 목록 조회 시 현재 사용자가 속하지 않은 팀만 조회하도록 수정 (RPC 함수 활용)
- 사용자가 하나 이상의 팀에 속해 있는지 확인하는 기능 추가 (`isUserInAnyTeam` 메서드)
- 팀 목록이 비어있을 때 적절한 UI 피드백 추가

## 📌 리뷰사항
- 팀 추가 선택 및 선택 취소, 로그인 후 첫 팀 선택의 로직이 이상하지 않은지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 코드가 빌드 및 실행에 문제 없는가
- [x] 파일, 변수, 주석 등이 컨벤션 규칙에 맞게 준수되었는가
- [x] 변경된 코드가 기존 기능에 영향을 주지 않도록 설계되었는가
- [x] 변경된 파일에 대한 문서나 주석이 업데이트 되었는가
- [x] 리뷰어가 이해하기 쉽도록 변경사항 설명 작성

closed: #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 소속된 팀이 없을 때 안내 메시지를 표시하고, 팀 선택 화면에 "취소" 버튼이 추가되었습니다.
  - 사용자가 팀에 소속되어 있는지 확인하는 기능이 추가되었습니다.

- **기능 개선**
  - 팀 선택 관련 메타데이터 및 UI 용어가 "선호 팀 선택"으로 통일되었습니다.
  - 팀 목록 조회 시, 사용자가 소속되지 않은 팀만 표시하도록 개선되었습니다.
  - 팀 선택 완료 또는 취소 시 "내 파일"로 이동하는 흐름이 추가되었습니다.

- **버그 수정**
  - 테스트 코드 및 내부 로직에서 팀 선택 관련 명칭과 파라미터가 일관되게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->