### PR TITLE
fix/로고 경로 수정, 폴더 없음 시 null이 아닌 UnKnown으로 표시하게 수정

### DIFF
--- a/lib/dashboard/presentation/component/workbook_view/workbook_grid_item.dart
+++ b/lib/dashboard/presentation/component/workbook_view/workbook_grid_item.dart
@@ -129,7 +129,7 @@ class WorkbookGridItem extends ConsumerWidget {
                               const Gap(10),
                               _gridTile(
                                 Icons.folder,
-                                workbook.folderName.toString(),
+                                (workbook.folderName ?? 'Unknown').toString(),
                               ),
                               const Spacer(),
                             ],

--- a/lib/dashboard/presentation/dashboard_screen.dart
+++ b/lib/dashboard/presentation/dashboard_screen.dart
@@ -340,7 +340,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                       ),
                       child: Center(
                         child: Image.asset(
-                          'images/mongo_ai_logo.png',
+                          'assets/images/mongo_ai_logo.png',
                           width: 16,
                           height: 16,
                         ),


### PR DESCRIPTION
## 🔍 변경사항 요약
- 대시보드 로고 경로 수정하였고, 폴더 없음 시 null이 아닌 UnKnown으로 표시하게 수정하였습니다.

## 📌 리뷰사항
- 특별히 없습니다.

## ✅ 체크리스트
- [x] 버그 수정 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 폴더 이름이 없는 경우 'Unknown'으로 표시되어 빈 값 대신 명확하게 안내됩니다.

- **스타일**
  - 사이드바의 Mongo AI 로고 이미지 경로가 변경되어 이미지가 올바르게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->